### PR TITLE
Moved to using labels defined in operator-rs

### DIFF
--- a/crd/src/main.rs
+++ b/crd/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
         Err(err) => panic!("Failed to retrieve CRD: [{}]", err),
     };
     match fs::write(target_file, string_schema) {
-        Ok(()) => println!("Succesfully wrote CRD to file."),
+        Ok(()) => println!("Successfully wrote CRD to file."),
         Err(err) => println!("Failed to write file: [{}]", err),
     }
 }


### PR DESCRIPTION
Previously this operator used custom labels defined only by this operator to track role_group, node_type and cluster name.

This PR changes this behavior to instead use the best practice labels as recommended by Kubernetes [1].

These labels are defined in the operator framework.

The PR assigns these as follows:

```
app.kubernetes.io/instance -> for the name of the service the pod belongs to (owner of the pod)
app.kubernetes.io/version -> for the deployed kafka version
app.kubernetes.io/component -> for the node type, i.e. "broker" at the moment
app.kubernetes.io/role-group -> for the groups defined in inventory
```

[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/