### PR TITLE
Removed label selector schema and switched to the one provided in ope…

### DIFF
--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,10 +1,8 @@
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use kube::CustomResource;
-use schemars::gen::SchemaGenerator;
-use schemars::schema::Schema;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_value, json};
+use stackable_operator::label_selector::schema;
 use stackable_operator::Crd;
 use std::collections::HashMap;
 
@@ -72,72 +70,3 @@ pub struct SelectorAndConfig<T> {
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KafkaConfig {}
-
-pub fn schema(_: &mut SchemaGenerator) -> Schema {
-    from_value(json!({
-      "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
-      "properties": {
-        "matchExpressions": {
-          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-          "items": {
-            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-            "properties": {
-              "key": {
-                "description": "key is the label key that the selector applies to.",
-                "type": "string",
-                "x-kubernetes-patch-merge-key": "key",
-                "x-kubernetes-patch-strategy": "merge"
-              },
-              "operator": {
-                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
-                "type": "string"
-              },
-              "values": {
-                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "key",
-              "operator"
-            ],
-            "type": "object"
-          },
-          "type": "array"
-        },
-        "matchLabels": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-          "type": "object"
-        }
-      },
-      "type": "object"
-    })).unwrap()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use schemars::gen::SchemaGenerator;
-    use stackable_operator::conditions::schema;
-
-    #[test]
-    fn print_crd() {
-        let schema = KafkaCluster::crd();
-        let string_schema = serde_yaml::to_string(&schema).unwrap();
-        println!("KafkaCluster CRD:\n{}\n", string_schema);
-    }
-
-    #[test]
-    fn print_schema() {
-        let schema = schema(&mut SchemaGenerator::default());
-
-        let string_schema = serde_yaml::to_string(&schema).unwrap();
-        println!("LabelSelector Schema:\n{}\n", string_schema);
-    }
-}


### PR DESCRIPTION
…rator-rs. Removed the generation via test since there is a binary which does it.

We generate the crd via binary differently in different operators. Here we have it n the crd package, the binary automatically replaces the actual crd (which i like). In other operators it is located in "server" and only prints the content of the crd (which leads to copy and paste). 

I think we should unify that? I like the approach here, what do you guys think?