### PR TITLE
Change serialization for KafkaVersion enum to use strum instead of serde_json

### DIFF
--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -28,20 +28,9 @@ impl Crd for KafkaCluster {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    Eq,
-    JsonSchema,
-    PartialEq,
-    Serialize,
-    strum_macros::Display,
-    strum_macros::EnumString,
-)]
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 pub enum KafkaVersion {
     #[serde(rename = "2.6.0")]
-    #[strum(serialize = "2.6.0")]
     v2_6_0,
 }
 

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -28,9 +28,20 @@ impl Crd for KafkaCluster {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    JsonSchema,
+    PartialEq,
+    Serialize,
+    strum_macros::Display,
+    strum_macros::EnumString,
+)]
 pub enum KafkaVersion {
     #[serde(rename = "2.6.0")]
+    #[strum(serialize = "2.6.0")]
     v2_6_0,
 }
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -271,9 +271,14 @@ impl KafkaState {
                         node_labels
                             .insert(String::from(APP_ROLE_GROUP_LABEL), String::from(role_group));
                         node_labels.insert(String::from(APP_INSTANCE_LABEL), self.context.name());
+                        // unwrap is ok to use here, as this comes from a hard coded object and should
+                        // really not fail!
                         node_labels.insert(
                             String::from(APP_VERSION_LABEL),
-                            serde_json::json!(&self.kafka_cluster.spec.version).to_string(),
+                            serde_json::json!(&self.kafka_cluster.spec.version)
+                                .as_str()
+                                .unwrap()
+                                .to_owned(),
                         );
 
                         // Create a pod for this node, role and group combination

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -273,7 +273,7 @@ impl KafkaState {
                         node_labels.insert(String::from(APP_INSTANCE_LABEL), self.context.name());
                         node_labels.insert(
                             String::from(APP_VERSION_LABEL),
-                            serde_json::json!(&self.kafka_cluster.spec.version).to_string(),
+                            self.kafka_cluster.spec.version.clone().to_string(),
                         );
 
                         // Create a pod for this node, role and group combination

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -273,7 +273,7 @@ impl KafkaState {
                         node_labels.insert(String::from(APP_INSTANCE_LABEL), self.context.name());
                         node_labels.insert(
                             String::from(APP_VERSION_LABEL),
-                            self.kafka_cluster.spec.version.clone().to_string(),
+                            serde_json::json!(&self.kafka_cluster.spec.version).to_string(),
                         );
 
                         // Create a pod for this node, role and group combination


### PR DESCRIPTION
The serde variant enclosed the version string in "" (correctly so) - which is not allowed as label content in K8s, since it does not start and end with an alphanumeric character.

