### PR TITLE
Changes internal representation of Kafka version and include Scala version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,15 +638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
-dependencies = [
- "unindent",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b961ca336c5632e93880ee91b3ca879f1499b835daa74dd726809f6196320b7f"
+checksum = "c77c86a545c460cffcb2e5f558392e2e6a1edcc9d463cf092bf4ec3c7990641d"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -1587,7 +1578,6 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "stackable-kafka-crd"
 version = "0.1.0"
 dependencies = [
- "indoc",
  "k8s-openapi",
  "kube 0.52.0",
  "kube-runtime 0.52.0",
@@ -2043,12 +2033,6 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "unindent"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1300,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b961ca336c5632e93880ee91b3ca879f1499b835daa74dd726809f6196320b7f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,9 +1587,11 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "stackable-kafka-crd"
 version = "0.1.0"
 dependencies = [
+ "indoc",
  "k8s-openapi",
  "kube 0.52.0",
  "kube-runtime 0.52.0",
+ "rstest",
  "schemars",
  "serde",
  "serde_json",
@@ -1679,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2010,6 +2043,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "untrusted"

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -19,9 +19,7 @@ strum_macros = "0.20"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
-indoc = "1.0"
-rstest = "0.8"
-serde_yaml = "0.8"
+rstest = "0.9"
 
 [features]
 default = ["native-tls"]

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -19,6 +19,9 @@ strum_macros = "0.20"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
+indoc = "1.0"
+rstest = "0.8"
+serde_yaml = "0.8"
 
 [features]
 default = ["native-tls"]

--- a/crd/kafkaclusters.crd.yaml
+++ b/crd/kafkaclusters.crd.yaml
@@ -33,7 +33,7 @@ spec:
                             nullable: true
                             type: object
                           instances:
-                            format: uint8
+                            format: uint16
                             minimum: 0.0
                             type: integer
                           instancesPerNode:
@@ -80,9 +80,15 @@ spec:
                     - selectors
                   type: object
                 version:
-                  enum:
-                    - 2.6.0
-                  type: string
+                  properties:
+                    kafka_version:
+                      type: string
+                    scala_version:
+                      nullable: true
+                      type: string
+                  required:
+                    - kafka_version
+                  type: object
                 zooKeeperReference:
                   description: This is the address to a namespaced resource.
                   properties:

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use stackable_operator::label_selector::schema;
 use stackable_operator::Crd;
 use std::collections::HashMap;
+use std::fmt;
+use std::fmt::{Display, Formatter};
 
 #[derive(Clone, CustomResource, Debug, Deserialize, JsonSchema, Serialize)]
 #[kube(
@@ -27,11 +29,35 @@ impl Crd for KafkaCluster {
     const CRD_DEFINITION: &'static str = include_str!("../kafkaclusters.crd.yaml");
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
-pub enum KafkaVersion {
-    #[serde(rename = "2.6.0")]
-    v2_6_0,
+pub struct KafkaVersion {
+    kafka_version: String,
+    scala_version: Option<String>,
+}
+
+impl KafkaVersion {
+    pub const DEFAULT_SCALA_VERSION: &'static str = "2.13";
+
+    pub fn get_kafka_version(&self) -> &str {
+        &self.kafka_version
+    }
+
+    pub fn get_scala_version(&self) -> &str {
+        &self
+            .scala_version
+            .as_deref()
+            .unwrap_or(Self::DEFAULT_SCALA_VERSION)
+    }
+
+    pub fn get_fully_qualified_version(&self) -> String {
+        format!("{}-{}", self.get_scala_version(), self.get_kafka_version())
+    }
+}
+
+impl Display for KafkaVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.get_fully_qualified_version())
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
@@ -70,3 +96,30 @@ pub struct SelectorAndConfig<T> {
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KafkaConfig {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::no_scala_version(
+    indoc! {"
+          kafka_version: 2.6.0
+      "},
+    "2.13-2.6.0"
+    )]
+    #[case::with_scala_version(
+    indoc! {"
+          kafka_version: 2.8.0
+          scala_version: 2.12
+      "},
+    "2.12-2.8.0"
+    )]
+    fn test_version(#[case] input: &str, #[case] expected_output: &str) {
+        let version: KafkaVersion = serde_yaml::from_str(&input)
+            .expect("deserializing a known-good value should not fail!");
+        assert_eq!(version.get_fully_qualified_version(), expected_output);
+    }
+}

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -49,14 +49,14 @@ impl KafkaVersion {
             .unwrap_or(Self::DEFAULT_SCALA_VERSION)
     }
 
-    pub fn get_fully_qualified_version(&self) -> String {
+    pub fn fully_qualified_version(&self) -> String {
         format!("{}-{}", self.scala_version(), self.kafka_version())
     }
 }
 
 impl Display for KafkaVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.get_fully_qualified_version())
+        write!(f, "{}", self.fully_qualified_version())
     }
 }
 
@@ -119,6 +119,6 @@ mod tests {
     fn test_version(#[case] input: &str, #[case] expected_output: &str) {
         let version: KafkaVersion = serde_yaml::from_str(&input)
             .expect("deserializing a known-good value should not fail!");
-        assert_eq!(version.get_fully_qualified_version(), expected_output);
+        assert_eq!(version.fully_qualified_version(), expected_output);
     }
 }

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -38,11 +38,11 @@ pub struct KafkaVersion {
 impl KafkaVersion {
     pub const DEFAULT_SCALA_VERSION: &'static str = "2.13";
 
-    pub fn get_kafka_version(&self) -> &str {
+    pub fn kafka_version(&self) -> &str {
         &self.kafka_version
     }
 
-    pub fn get_scala_version(&self) -> &str {
+    pub fn scala_version(&self) -> &str {
         &self
             .scala_version
             .as_deref()
@@ -50,7 +50,7 @@ impl KafkaVersion {
     }
 
     pub fn get_fully_qualified_version(&self) -> String {
-        format!("{}-{}", self.get_scala_version(), self.get_kafka_version())
+        format!("{}-{}", self.scala_version(), self.kafka_version())
     }
 }
 
@@ -100,22 +100,21 @@ pub struct KafkaConfig {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use indoc::indoc;
     use rstest::rstest;
 
     #[rstest]
     #[case::no_scala_version(
-    indoc! {"
-          kafka_version: 2.6.0
-      "},
-    "2.13-2.6.0"
+        "
+        kafka_version: 2.6.0
+      ",
+        "2.13-2.6.0"
     )]
     #[case::with_scala_version(
-    indoc! {"
-          kafka_version: 2.8.0
-          scala_version: 2.12
-      "},
-    "2.12-2.8.0"
+        "
+        kafka_version: 2.8.0
+        scala_version: 2.12
+      ",
+        "2.12-2.8.0"
     )]
     fn test_version(#[case] input: &str, #[case] expected_output: &str) {
         let version: KafkaVersion = serde_yaml::from_str(&input)

--- a/examples/simple-kafkacluster.yaml
+++ b/examples/simple-kafkacluster.yaml
@@ -3,7 +3,8 @@ kind: KafkaCluster
 metadata:
   name: simple
 spec:
-  version: 2.6.0
+  version:
+    kafka_version: 2.6.0
   zooKeeperReference:
     namespace: default
     name: simple

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -271,12 +271,10 @@ impl KafkaState {
                         node_labels
                             .insert(String::from(APP_ROLE_GROUP_LABEL), String::from(role_group));
                         node_labels.insert(String::from(APP_INSTANCE_LABEL), self.context.name());
-                        // unwrap is ok to use here, as this comes from a hard coded object and should
-                        // really not fail!
                         let version: &KafkaVersion = &self.kafka_cluster.spec.version;
                         node_labels.insert(
                             String::from(APP_VERSION_LABEL),
-                            version.get_fully_qualified_version(),
+                            version.fully_qualified_version(),
                         );
 
                         // Create a pod for this node, role and group combination
@@ -451,13 +449,13 @@ fn build_pod(
             containers: vec![Container {
                 image: Some(format!(
                     "stackable/kafka:{}",
-                    resource.spec.version.get_fully_qualified_version()
+                    resource.spec.version.fully_qualified_version()
                 )),
                 name: "kafka".to_string(),
                 command: Some(vec![
                     format!(
                         "kafka_{}/bin/kafka-server-start.sh",
-                        resource.spec.version.get_fully_qualified_version()
+                        resource.spec.version.fully_qualified_version()
                     ),
                     "{{ configroot }}/config/server.properties".to_string(),
                 ]),

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -13,7 +13,7 @@ use kube::api::ListParams;
 use serde_json::json;
 use tracing::{debug, info, trace, warn};
 
-use stackable_kafka_crd::{KafkaCluster, KafkaClusterSpec};
+use stackable_kafka_crd::{KafkaCluster, KafkaClusterSpec, KafkaVersion};
 use stackable_operator::client::Client;
 use stackable_operator::controller::{Controller, ControllerStrategy, ReconciliationState};
 use stackable_operator::labels::{
@@ -273,12 +273,10 @@ impl KafkaState {
                         node_labels.insert(String::from(APP_INSTANCE_LABEL), self.context.name());
                         // unwrap is ok to use here, as this comes from a hard coded object and should
                         // really not fail!
+                        let version: &KafkaVersion = &self.kafka_cluster.spec.version;
                         node_labels.insert(
                             String::from(APP_VERSION_LABEL),
-                            serde_json::json!(&self.kafka_cluster.spec.version)
-                                .as_str()
-                                .unwrap()
-                                .to_owned(),
+                            version.get_fully_qualified_version(),
                         );
 
                         // Create a pod for this node, role and group combination
@@ -453,11 +451,14 @@ fn build_pod(
             containers: vec![Container {
                 image: Some(format!(
                     "stackable/kafka:{}",
-                    serde_json::json!(resource.spec.version).as_str().unwrap()
+                    &resource.spec.version.get_fully_qualified_version()
                 )),
                 name: "kafka".to_string(),
                 command: Some(vec![
-                    "kafka_2.12-2.6.0/bin/kafka-server-start.sh".to_string(), // TODO: Don't hardcode this
+                    format!(
+                        "kafka_{}/bin/kafka-server-start.sh",
+                        &resource.spec.version.get_fully_qualified_version()
+                    ),
                     "{{ configroot }}/config/server.properties".to_string(),
                 ]),
                 volume_mounts: Some(vec![VolumeMount {

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -451,13 +451,13 @@ fn build_pod(
             containers: vec![Container {
                 image: Some(format!(
                     "stackable/kafka:{}",
-                    &resource.spec.version.get_fully_qualified_version()
+                    resource.spec.version.get_fully_qualified_version()
                 )),
                 name: "kafka".to_string(),
                 command: Some(vec![
                     format!(
                         "kafka_{}/bin/kafka-server-start.sh",
-                        &resource.spec.version.get_fully_qualified_version()
+                        resource.spec.version.get_fully_qualified_version()
                     ),
                     "{{ configroot }}/config/server.properties".to_string(),
                 ]),


### PR DESCRIPTION
Changes internal representation of Kafka version to a struct instead of an enum.
This version representation also includes the scala version that Kafka was compiled for, which was hard coded before.

Removes hard coded Kafka version in container command.

fixes #75
fixes #78
fixes #79