### PR TITLE
Idea on how to extend the KafkaVersion struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,14 +1583,17 @@ dependencies = [
  "k8s-openapi",
  "kube 0.52.0",
  "kube-runtime 0.52.0",
+ "lazy_static",
  "rstest",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
  "stackable-operator",
  "strum",
  "strum_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -10,12 +10,15 @@ stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git",
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"]  }
 kube = { version = "0.52", default-features = false, features = ["jsonpatch", "derive"] }
 kube-runtime = "0.52"
+lazy_static = "1"
 schemars = "0.8"
+semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0" # Needed by the CustomResource annotation
 serde_yaml = "0.8"
 strum = "0.20"
 strum_macros = "0.20"
+thiserror = "1"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }

--- a/crd/src/error.rs
+++ b/crd/src/error.rs
@@ -1,0 +1,15 @@
+use semver::SemVerError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Error parsing version from string: {source}")]
+    IllegalVersionString {
+        #[from]
+        source: SemVerError,
+    },
+
+    #[error("Unsupported Kafka version encountered: [{version}] - [{reason}]")]
+    UnsupportedKafkaVersion { version: String, reason: String },
+}
+
+pub type KafkaOperatorResult<T> = std::result::Result<T, Error>;

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,6 +1,12 @@
+mod error;
+
+use crate::error::Error::UnsupportedKafkaVersion;
+use error::KafkaOperatorResult as Result;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use kube::CustomResource;
+use lazy_static::lazy_static;
 use schemars::JsonSchema;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use stackable_operator::label_selector::schema;
 use stackable_operator::Crd;
@@ -29,6 +35,24 @@ impl Crd for KafkaCluster {
     const CRD_DEFINITION: &'static str = include_str!("../kafkaclusters.crd.yaml");
 }
 
+lazy_static! {
+    static ref DEFAULT_SCALA_VERSION: Vec<(Version, &'static str)> = {
+        vec![("2.6.0", "2.13"), ("2.0.1", "2.12"), ("0.9.0", "2.11")]
+            .iter()
+            .map(|(kafka, scala)| (Version::parse(kafka).unwrap(), *scala))
+            .collect()
+    };
+    static ref MINIMAL_SUPPORTED_KAFKA_VERSION: Version = { Version::parse("2.5.0").unwrap() };
+}
+
+fn default_scala_version(kafka_version: &Version) -> &'static str {
+    DEFAULT_SCALA_VERSION
+        .iter()
+        .find(|(kafka, scala)| kafka <= &kafka_version)
+        .unwrap()
+        .1
+}
+
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 pub struct KafkaVersion {
     kafka_version: String,
@@ -36,27 +60,43 @@ pub struct KafkaVersion {
 }
 
 impl KafkaVersion {
-    pub const DEFAULT_SCALA_VERSION: &'static str = "2.13";
+    pub fn kafka_version(&self) -> Result<Version> {
+        let version = Version::parse(&self.kafka_version)?;
 
-    pub fn kafka_version(&self) -> &str {
-        &self.kafka_version
+        if version < *MINIMAL_SUPPORTED_KAFKA_VERSION {
+            return Err(UnsupportedKafkaVersion {
+                version: version.to_string(),
+                reason: format!(
+                    "the minimum supported Kafka version is {}",
+                    *MINIMAL_SUPPORTED_KAFKA_VERSION
+                ),
+            });
+        }
+
+        Ok(version)
     }
 
-    pub fn scala_version(&self) -> &str {
-        &self
-            .scala_version
-            .as_deref()
-            .unwrap_or(Self::DEFAULT_SCALA_VERSION)
+    pub fn scala_version(&self) -> Result<Version> {
+        match &self.scala_version {
+            Some(scala_version) => Ok(Version::parse(&scala_version)?),
+            None => Ok(Version::parse(default_scala_version(
+                &self.kafka_version()?,
+            ))?),
+        }
     }
 
-    pub fn fully_qualified_version(&self) -> String {
-        format!("{}-{}", self.scala_version(), self.kafka_version())
+    pub fn fully_qualified_version(&self) -> Result<String> {
+        Ok(format!(
+            "{}-{}",
+            self.scala_version()?,
+            self.kafka_version()?
+        ))
     }
 }
 
 impl Display for KafkaVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.fully_qualified_version())
+        write!(f, "{}", self.fully_qualified_version().unwrap())
     }
 }
 
@@ -119,6 +159,38 @@ mod tests {
     fn test_version(#[case] input: &str, #[case] expected_output: &str) {
         let version: KafkaVersion = serde_yaml::from_str(&input)
             .expect("deserializing a known-good value should not fail!");
-        assert_eq!(version.fully_qualified_version(), expected_output);
+        assert_eq!(version.fully_qualified_version().unwrap(), expected_output);
+    }
+
+    #[rstest]
+    // These test cases are taken from the Kafka docs at
+    // https://kafka.apache.org/downloads
+    #[case::v2_8_0("2.8.0", "2.13")]
+    #[case::v2_7_0("2.7.0", "2.13")]
+    #[case::v2_6_2("2.6.2", "2.13")]
+    #[case::v2_6_1("2.6.1", "2.13")]
+    #[case::v2_6_0("2.6.0", "2.13")]
+    #[case::v2_5_1("2.5.1", "2.12")]
+    #[case::v2_5_0("2.5.0", "2.12")]
+    #[case::v2_4_1("2.4.1", "2.12")]
+    #[case::v2_4_0("2.4.0", "2.12")]
+    #[case::v2_3_1("2.3.1", "2.12")]
+    #[case::v2_3_0("2.3.0", "2.12")]
+    #[case::v2_2_2("2.2.2", "2.12")]
+    #[case::v2_2_1("2.2.1", "2.12")]
+    #[case::v2_2_0("2.2.0", "2.12")]
+    #[case::v2_1_1("2.1.1", "2.12")]
+    #[case::v2_1_0("2.1.0", "2.12")]
+    #[case::v2_0_1("2.0.1", "2.12")]
+    #[case::v2_0_0("2.0.0", "2.11")]
+    #[case::v1_1_1("1.1.1", "2.11")]
+    #[case::v1_1_0("1.1.0", "2.11")]
+    #[case::v1_0_2("1.0.2", "2.11")]
+    #[case::v1_0_1("1.0.1", "2.11")]
+    #[case::v1_0_0("1.0.0", "2.11")]
+    fn test_scala(#[case] input: &str, #[case] expected_output: &str) {
+        let output = default_scala_version(&Version::parse(input).unwrap());
+
+        assert_eq!(expected_output, output);
     }
 }


### PR DESCRIPTION
This is my current stab at implementing a lookup for the default scala version.

I am not yet entirely happy with this, as any call to get a version would need to return a result due to parsing versions.
In principle I'd prefer to parse once when creating the object, but that would mean a custom deserializer - which is fine in principle, but would mean that there is a failure when the operator tries to retrieve the cluster cr. This may limit the options we have of what message to show end users.

This PR is for discussion only at the moment @siegfriedweber @lfrancke  in case you are interested, both of you reviewed the PR where I started this work.