### PR TITLE
Add name of node that a pod is scheduled on to the podname

### DIFF
--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -277,12 +277,15 @@ impl KafkaState {
                             version.fully_qualified_version(),
                         );
 
+                        // If the node name is not part of the pod name we get duplicate names
+                        // which prevents all pods from being created
+                        let pod_name_with_node = format!("{}-{}", pod_name, node_name);
                         // Create a pod for this node, role and group combination
                         let pod = build_pod(
                             &self.context.resource,
                             node_name,
                             &node_labels,
-                            &pod_name,
+                            &pod_name_with_node,
                             &cm_name,
                         )?;
                         self.context.client.create(&pod).await?;


### PR DESCRIPTION
In order to avoid naming collisions of pods this PR adds the name of the node that a pod is scheduled on to the pod name.
This will not help once we start supporting multiple pods on the same node, but there are plans to use `generateName` instead of `Name` - this would provide unique hashes as part of the names.

Another factor to consider is that this method only works as long as the operator schedules pods itself, instead of relying on the pod scheduler from Kubernetes.