### PR TITLE
ZooKeeper connect string is now retrieved via zookeeper get_zk_connec…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,20 +3,10 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -194,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d6ddad5866bb2170686ed03f6839d31a76e5407d80b1c334a2c24618543ffa"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -204,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ced1fd13dc386d5a8315899de465708cf34ee2a6d9394654515214e67bb846"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
@@ -218,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7a1445d54b2f9792e3b31a3e715feabbace393f38dc4ffd49d94ee9bc487d5"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
  "quote",
@@ -475,7 +465,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error 2.0.0",
+ "quick-error 2.0.1",
  "serde",
  "serde_json",
 ]
@@ -517,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -528,15 +518,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.6"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "humantime"
@@ -549,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -562,7 +552,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.6",
+ "pin-project 1.0.7",
  "socket2",
  "tokio",
  "tower-service",
@@ -620,9 +610,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -647,9 +637,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -694,41 +684,6 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362fa64584999b25670b73f4874d716c14b039351b2da6740c7610a3d2e970cf"
-dependencies = [
- "Inflector",
- "base64",
- "bytes",
- "chrono",
- "dirs-next",
- "either",
- "futures",
- "http",
- "hyper",
- "hyper-timeout",
- "hyper-tls",
- "jsonpath_lib",
- "k8s-openapi",
- "log",
- "openssl",
- "pem",
- "pin-project 1.0.6",
- "serde",
- "serde_json",
- "serde_yaml",
- "static_assertions",
- "thiserror",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower",
- "url",
-]
-
-[[package]]
-name = "kube"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b2fbe85ad92f8435a0f52072f55bd7f0843e082c8e461e56d1ce29440554c8"
@@ -747,11 +702,11 @@ dependencies = [
  "json-patch",
  "jsonpath_lib",
  "k8s-openapi",
- "kube-derive 0.52.0",
+ "kube-derive",
  "log",
  "openssl",
  "pem",
- "pin-project 1.0.6",
+ "pin-project 1.0.7",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -764,19 +719,6 @@ dependencies = [
  "tower",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "kube-derive"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b58ffd8a1bd162d64ac423d7c1ea1de70a4c743a9d18bc1bf364f293fcd184a"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
 ]
 
 [[package]]
@@ -794,25 +736,6 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82772bce36d85f6825d7db915e117c5bbf1cc13e8c95cd91281a55ec7cfd9bb"
-dependencies = [
- "dashmap",
- "derivative",
- "futures",
- "k8s-openapi",
- "kube 0.49.0",
- "pin-project 1.0.6",
- "serde",
- "smallvec",
- "snafu",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "kube-runtime"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdbf7b51e6a4984e929dab0bd13b61592b750a3385e298aaa9100c4830205a12"
@@ -821,8 +744,8 @@ dependencies = [
  "derivative",
  "futures",
  "k8s-openapi",
- "kube 0.52.0",
- "pin-project 1.0.6",
+ "kube",
+ "pin-project 1.0.7",
  "serde",
  "smallvec",
  "snafu",
@@ -838,9 +761,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "linked-hash-map"
@@ -880,9 +803,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mio"
@@ -976,9 +899,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -990,15 +913,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
@@ -1009,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218"
+checksum = "b50b8919aecb97e5ee9aceef27e24f39c46b11831130f4a6b7b091ec5de0de12"
 dependencies = [
  "num-traits",
 ]
@@ -1087,11 +1010,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal 1.0.6",
+ "pin-project-internal 1.0.7",
 ]
 
 [[package]]
@@ -1107,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1169,9 +1092,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1224,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -1243,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1264,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1316,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64",
  "log",
@@ -1527,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -1581,14 +1504,15 @@ name = "stackable-kafka-crd"
 version = "0.1.0"
 dependencies = [
  "k8s-openapi",
- "kube 0.52.0",
- "kube-runtime 0.52.0",
+ "kube",
+ "kube-runtime",
  "rstest",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "stackable-operator",
+ "stackable-zookeeper-crd",
  "strum",
  "strum_macros",
 ]
@@ -1601,8 +1525,8 @@ dependencies = [
  "futures",
  "handlebars",
  "k8s-openapi",
- "kube 0.52.0",
- "kube-runtime 0.52.0",
+ "kube",
+ "kube-runtime",
  "serde",
  "serde_json",
  "stackable-kafka-crd",
@@ -1629,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.1.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#1808a3cfb5738d91f641174988c8d795f996527c"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#3858d1c63ffabdd5d26fd53f1bafc4c313db6fcd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1638,8 +1562,8 @@ dependencies = [
  "futures",
  "json-patch",
  "k8s-openapi",
- "kube 0.52.0",
- "kube-runtime 0.52.0",
+ "kube",
+ "kube-runtime",
  "lazy_static",
  "regex",
  "schemars",
@@ -1657,19 +1581,21 @@ dependencies = [
 [[package]]
 name = "stackable-zookeeper-crd"
 version = "0.1.0"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#21000abf114a1b6799940d82f2893defbee56fee"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#ffd0d3d5fc47d0f9878f3675eeaae741ca09483b"
 dependencies = [
  "k8s-openapi",
- "kube 0.49.0",
- "kube-derive 0.49.0",
- "kube-runtime 0.49.0",
+ "kube",
+ "kube-runtime",
  "schemars",
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "stackable-operator",
  "strum",
  "strum_macros",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1852,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1867,13 +1793,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 1.0.6",
+ "pin-project 1.0.7",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -1932,7 +1858,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.6",
+ "pin-project 1.0.7",
  "tracing",
 ]
 
@@ -1959,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2032,9 +1958,9 @@ checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "untrusted"
@@ -2044,9 +1970,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2065,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "want"
@@ -2087,9 +2013,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2097,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2112,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2122,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,15 +2061,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch="main" }
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "main"}
 
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"]  }
 kube = { version = "0.52", default-features = false, features = ["jsonpatch", "derive"] }

--- a/crd/kafkaclusters.crd.yaml
+++ b/crd/kafkaclusters.crd.yaml
@@ -89,9 +89,12 @@ spec:
                   required:
                     - kafka_version
                   type: object
-                zooKeeperReference:
-                  description: This is the address to a namespaced resource.
+                zookeeperReference:
+                  description: Contains all necessary information identify a Stackable managed ZooKeeper ensemble and build a connection string for it. The main purpose for this struct is for other operators that need to reference a ZooKeeper ensemble to use in their CRDs. This has the benefit of keeping references to Zookeeper ensembles consistent throughout the entire stack.
                   properties:
+                    chroot:
+                      nullable: true
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -103,7 +106,7 @@ spec:
               required:
                 - brokers
                 - version
-                - zooKeeperReference
+                - zookeeperReference
               type: object
             status:
               nullable: true

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use stackable_operator::label_selector::schema;
 use stackable_operator::Crd;
+use stackable_zookeeper_crd::util::ZookeeperReference;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -21,7 +22,7 @@ use std::fmt::{Display, Formatter};
 pub struct KafkaClusterSpec {
     pub version: KafkaVersion,
     pub brokers: NodeGroup<KafkaConfig>,
-    pub zoo_keeper_reference: stackable_zookeeper_crd::util::ZookeeperReference,
+    pub zookeeper_reference: ZookeeperReference,
 }
 
 impl Crd for KafkaCluster {

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -21,7 +21,7 @@ use std::fmt::{Display, Formatter};
 pub struct KafkaClusterSpec {
     pub version: KafkaVersion,
     pub brokers: NodeGroup<KafkaConfig>,
-    pub zoo_keeper_reference: NamespaceName,
+    pub zoo_keeper_reference: stackable_zookeeper_crd::util::ZookeeperReference,
 }
 
 impl Crd for KafkaCluster {
@@ -62,19 +62,6 @@ impl Display for KafkaVersion {
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
 pub struct KafkaClusterStatus {}
-
-/// This is the address to a namespaced resource.
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
-pub struct NamespaceName {
-    pub namespace: String,
-    pub name: String,
-}
-
-impl NamespaceName {
-    pub fn new(namespace: String, name: String) -> Self {
-        NamespaceName { namespace, name }
-    }
-}
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/examples/simple-kafkacluster.yaml
+++ b/examples/simple-kafkacluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: simple
 spec:
   version:
-    kafka_version: 2.6.0
-  zooKeeperReference:
+    kafka_version: 2.8.0
+  zookeeperReference:
     namespace: default
     name: simple
   brokers:
@@ -13,6 +13,6 @@ spec:
       default:
         selector:
           matchLabels:
-            kubernetes.io/hostname: soenke-laptop
+            kubernetes.io/hostname: debian
         instances: 3
         instancesPerNode: 1

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
         source: stackable_operator::error::Error,
     },
 
-    #[error("Error during reconciliation: {0}")]
-    ReconcileError(String),
+    #[error("Error from ZooKeeper: {source}")]
+    ZookeeperError {
+        #[from]
+        source: stackable_zookeeper_crd::error::Error,
+    },
 }

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -25,8 +25,6 @@ use stackable_operator::reconcile::{
     ContinuationStrategy, ReconcileFunctionAction, ReconcileResult, ReconciliationContext,
 };
 
-use stackable_zookeeper_crd::ZooKeeperCluster;
-
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use kube::Api;
 use stackable_operator::error::OperatorResult;
@@ -57,38 +55,30 @@ pub enum KafkaNodeType {
 struct KafkaState {
     context: ReconciliationContext<KafkaCluster>,
     kafka_cluster: KafkaCluster,
-    zk_cluster: Option<ZooKeeperCluster>,
+    zoo_keeper_info: Option<stackable_zookeeper_crd::util::ZookeeperConnectionInformation>,
     existing_pods: Vec<Pod>,
     eligible_nodes: HashMap<KafkaNodeType, HashMap<String, Vec<Node>>>,
 }
 
 impl KafkaState {
-    async fn check_zookeeper_reference(&mut self) -> KafkaReconcileResult {
-        debug!("Checking ZookeeperReference exists.");
-        let api: Api<ZooKeeperCluster> = self
-            .context
-            .client
-            .get_namespaced_api(&self.kafka_cluster.spec.zoo_keeper_reference.namespace);
-        let zk_cluster = api
-            .get(&self.kafka_cluster.spec.zoo_keeper_reference.name)
-            .await;
+    async fn get_zookeeper_connection_information(&mut self) -> KafkaReconcileResult {
+        let zk_ref: &stackable_zookeeper_crd::util::ZookeeperReference =
+            &self.context.resource.spec.zoo_keeper_reference;
 
-        // TODO: We need to watch the ZooKeeper resource and do _something_ when it goes down or when its nodes are changed
-        let zk_cluster: ZooKeeperCluster = match zk_cluster {
-            Ok(zk) => zk,
-            Err(err) => {
-                warn!(?err,
-                    "Referencing a ZooKeeper cluster that does not exist (or some other error while fetching it): [{}/{}], we will requeue and check again",
-                    &self.kafka_cluster.spec.zoo_keeper_reference.namespace,
-                    &self.kafka_cluster.spec.zoo_keeper_reference.name
-                );
-                // TODO: Depending on the error either requeue or return an error (which'll requeue as well)
-                // For a not found we'd like to requeue but if there was a transport error we'd like to return it.
-                return Ok(ReconcileFunctionAction::Requeue(Duration::from_secs(10)));
-            }
-        };
+        if let Some(chroot) = zk_ref.chroot.as_deref() {
+            stackable_zookeeper_crd::util::is_valid_zookeeper_path(chroot)?;
+        }
 
-        self.zk_cluster = Some(zk_cluster);
+        let zookeeper_info =
+            stackable_zookeeper_crd::util::get_zk_connection_info(&self.context.client, zk_ref)
+                .await?;
+
+        debug!(
+            "Received ZooKeeper connect string: [{}]",
+            &zookeeper_info.connection_string
+        );
+
+        self.zoo_keeper_info = Some(zookeeper_info);
 
         Ok(ReconcileFunctionAction::Continue)
     }
@@ -115,7 +105,7 @@ impl KafkaState {
         eligible_nodes_map
     }
 
-    pub fn get_deletion_labels(&self) -> BTreeMap<String, Option<Vec<String>>> {
+    pub fn get_required_labels(&self) -> BTreeMap<String, Option<Vec<String>>> {
         let roles = KafkaNodeType::iter()
             .map(|role| role.to_string())
             .collect::<Vec<_>>();
@@ -134,40 +124,17 @@ impl KafkaState {
         mandatory_labels
     }
 
-    async fn create_config_map(&self, name: &str) -> Result<(), Error> {
-        match self
-            .context
-            .client
-            .get::<ConfigMap>(name, Some(&"default".to_string()))
-            .await
-        {
-            Ok(_) => {
-                debug!("ConfigMap [{}] already exists, skipping creation!", name);
-                return Ok(());
-            }
-            Err(e) => {
-                // TODO: This is shit, but works for now. If there is an actual error in comms with
-                //   K8S, it will most probably also occur further down and be properly handled
-                debug!("Error getting ConfigMap [{}]: [{:?}]", name, e);
-            }
-        }
-        let zk_spec = &self.zk_cluster.as_ref().ok_or_else(|| error::Error::ReconcileError("zk_spec missing, this is a programming error and should never happen. Please report in our issue tracker.".to_string()))?.spec;
-
-        // This retrieves all the nodes from the referenced ZooKeeper cluster and creates the
-        // required connection string for Kafka
-        // TODO: Port is currently hardcoded, this needs to change and in general it might make sense to move this functionality to a ZooKeeper library
-        let zk_servers: String = zk_spec
-            .servers
-            .iter()
-            .map(|server| format!("{}:2181", server.node_name))
-            .collect::<Vec<String>>()
-            .join(",");
-
+    async fn build_config_map(&self, name: &str) -> Result<Option<ConfigMap>, Error> {
         let mut labels = BTreeMap::new();
         labels.insert("kafka-name".to_string(), name);
 
         let mut options = HashMap::new();
-        options.insert("zookeeper.connect".to_string(), zk_servers);
+        if let Some(info) = &self.zoo_keeper_info {
+            options.insert(
+                "zookeeper.connect".to_string(),
+                info.connection_string.clone(),
+            );
+        }
 
         let mut handlebars = Handlebars::new();
         handlebars.set_strict_mode(true);
@@ -182,11 +149,40 @@ impl KafkaState {
         let mut data = BTreeMap::new();
         data.insert("server.properties".to_string(), config);
 
+        match self
+            .context
+            .client
+            .get::<ConfigMap>(name, Some(&self.context.namespace()))
+            .await
+        {
+            Ok(config_map) => {
+                if let Some(existing_config_map_data) = config_map.data {
+                    if existing_config_map_data == data {
+                        debug!(
+                            "ConfigMap [{}] already exists with identical data, skipping creation!",
+                            name
+                        );
+                        return Ok(None);
+                    } else {
+                        debug!(
+                            "ConfigMap [{}] already exists, but differs, recreating it!",
+                            name
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                // TODO: This is shit, but works for now. If there is an actual error in comes with
+                //   K8S, it will most probably also occur further down and be properly handled
+                debug!("Error getting ConfigMap [{}]: [{:?}]", name, e);
+            }
+        }
+
         // And now create the actual ConfigMap
         let cm =
             stackable_operator::config_map::create_config_map(&self.context.resource, &name, data)?;
-        self.context.client.create(&cm).await?;
-        Ok(())
+
+        Ok(Some(cm))
     }
 
     async fn delete_all_pods(&self) -> OperatorResult<ReconcileFunctionAction> {
@@ -213,7 +209,15 @@ impl KafkaState {
                     let cm_name = format!("{}-config", pod_name);
                     debug!("pod_name: [{}], cm_name: [{}]", pod_name, cm_name);
 
-                    self.create_config_map(&cm_name).await?;
+                    // build_config_map returns an Option<ConfigMap>:
+                    // None signals that a config map with identical name and data already exists -> nothing to be done
+                    // Some(ConfigMap) is returned if the config map either does not exists yet or the data differs -> create/override it
+                    // TODO: after the review i actually do not like the flow of that. Returning None if everything is ok does
+                    //    not make that much sense to me. Needs improvement.
+                    if let Some(cm) = self.build_config_map(&cm_name).await? {
+                        self.context.client.create(&cm).await?;
+                    }
+
                     debug!(
                         "Identify missing pods for [{}] role and group [{}]",
                         node_type, role_group
@@ -305,17 +309,17 @@ impl ReconciliationState for KafkaState {
     ) -> Pin<Box<dyn Future<Output = Result<ReconcileFunctionAction, Self::Error>> + Send + '_>>
     {
         info!("========================= Starting reconciliation =========================");
-        debug!("Deletion Labels: [{:?}]", &self.get_deletion_labels());
+        debug!("Deletion Labels: [{:?}]", &self.get_required_labels());
 
         Box::pin(async move {
             self.context
                 .handle_deletion(Box::pin(self.delete_all_pods()), FINALIZER_NAME, true)
                 .await?
-                .then(self.check_zookeeper_reference())
+                .then(self.get_zookeeper_connection_information())
                 .await?
                 .then(self.context.delete_illegal_pods(
                     self.existing_pods.as_slice(),
-                    &self.get_deletion_labels(),
+                    &self.get_required_labels(),
                     ContinuationStrategy::OneRequeue,
                 ))
                 .await?
@@ -394,7 +398,7 @@ impl ControllerStrategy for KafkaStrategy {
         Ok(KafkaState {
             kafka_cluster: context.resource.clone(),
             context,
-            zk_cluster: None,
+            zoo_keeper_info: None,
             existing_pods,
             eligible_nodes,
         })


### PR DESCRIPTION
…tion_info.

Adapted ZooKeeper to Zookeeper
Using zookeeper::util::ZookeeperReference instead of NamespaceName
Updated dependencies

There is still a bug if the config map exists but has different data, we get an reconcile error. 
I guess we need a create_or_override or similar in operator-rs? Didnt investigate further.