### PR TITLE
Update handlebars version to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.5.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+checksum = "28f0fe89affef47e2c9729030a8f6e79df34cb66b8a44ecf91dad43f31150559"
 dependencies = [
  "log",
  "pest",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -14,7 +14,7 @@ stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-op
 
 async-trait = "0.1"
 futures = "0.3"
-handlebars = "3"
+handlebars = "4.0"
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
 kube = { version = "0.52", default-features = false, features = ["jsonpatch"] }
 kube-runtime = "0.52"


### PR DESCRIPTION
This makes the following dependabot PR obsolete: https://github.com/stackabletech/kafka-operator/pull/105

It is a `bugfix` because the previous version of handlebars was _3_ instead of _3.0_.
