### PR TITLE
Manage ServiceAccount for brokers

### DIFF
--- a/deploy/helm/kafka-operator/templates/deployment.yaml
+++ b/deploy/helm/kafka-operator/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            KAFKA_BROKER_CLUSTERROLE: {{ .Release.Name }}-kafka-broker-clusterrole
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/helm/kafka-operator/templates/roles-kafka.yaml
+++ b/deploy/helm/kafka-operator/templates/roles-kafka.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-kafka-broker-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -50,8 +50,3 @@ If you wish to include integration with https://docs.stackable.tech/opa/index.ht
           default:
             replicas: 1
     EOF
-
-In either case, the Kafka pods must be bound to a role that has permission to `get` `Service` objects. This can be set up using kubectl:
-
-    kubectl create rolebinding kafka --clusterrole=view --serviceaccount=default:default
-

--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -16,7 +16,15 @@ use tracing::info_span;
 use tracing_futures::Instrument;
 use utils::erase_controller_result_type;
 
-pub async fn create_controller(client: Client, product_config: ProductConfigManager) {
+pub struct ControllerConfig {
+    pub broker_clusterrole: String,
+}
+
+pub async fn create_controller(
+    client: Client,
+    controller_config: ControllerConfig,
+    product_config: ProductConfigManager,
+) {
     let kafka_controller =
         Controller::new(client.get_all_api::<KafkaCluster>(), ListParams::default())
             .owns(client.get_all_api::<StatefulSet>(), ListParams::default())
@@ -28,6 +36,7 @@ pub async fn create_controller(client: Client, product_config: ProductConfigMana
                 kafka_controller::error_policy,
                 Context::new(kafka_controller::Ctx {
                     client: client.clone(),
+                    controller_config,
                     product_config,
                 }),
             )

--- a/rust/operator/src/utils.rs
+++ b/rust/operator/src/utils.rs
@@ -1,3 +1,4 @@
+use snafu::Snafu;
 use stackable_operator::kube::{
     core::DynamicObject,
     runtime::{controller::ReconcilerAction, reflector::ObjectRef},
@@ -13,4 +14,38 @@ pub fn erase_controller_result_type<K: Resource, E: std::error::Error + Send + S
 ) -> Result<(ObjectRef<DynamicObject>, ReconcilerAction), Box<dyn std::error::Error>> {
     let (obj_ref, action) = res?;
     Ok((obj_ref.erase(), action))
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(display(
+    "cannot build a local reference to {} from {}, because it is in another namespace",
+    obj,
+    peer
+))]
+pub struct NamespaceMismatchError {
+    obj: ObjectRef<DynamicObject>,
+    peer: ObjectRef<DynamicObject>,
+}
+pub trait ObjectRefExt {
+    fn name_in_ns_of<'a, KPeer: Resource<DynamicType = ()>>(
+        &'a self,
+        peer_obj: &KPeer,
+    ) -> Result<&'a str, NamespaceMismatchError>;
+}
+
+impl<K: Resource<DynamicType = ()>> ObjectRefExt for ObjectRef<K> {
+    fn name_in_ns_of<KPeer: Resource<DynamicType = ()>>(
+        &self,
+        peer_obj: &KPeer,
+    ) -> Result<&str, NamespaceMismatchError> {
+        if self.namespace == peer_obj.meta().namespace {
+            Ok(&self.name)
+        } else {
+            NamespaceMismatchSnafu {
+                obj: self.clone().erase(),
+                peer: ObjectRef::from_obj(peer_obj).erase(),
+            }
+            .fail()
+        }
+    }
 }


### PR DESCRIPTION
## Description

Fixes #273 and #274

One downside of this is that it makes it somewhat more annoying to run outside of K8s (for development), since the `ClusterRole` must be created manually.

One thing that's not addressed here is that the operator must now have permission to create `ServiceAccount` and `RoleBinding` objects, but this should probably go into templating instead...

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
