### PR TITLE
Fix issues on GKE

### DIFF
--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -151,7 +151,7 @@ properties:
       datatype:
         type: "string"
       recommendedValues:
-        - value: "/stackable/data"
+        - value: "/stackable/data/topicdata"
       roles:
         - name: "broker"
           required: true

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -378,7 +378,12 @@ fn build_broker_rolegroup_statefulset(
     // chowned to that user for it to be able to store data there.
     let mut container_chown = ContainerBuilder::new("chown-data")
         .image(&image)
-        .command(vec!["/bin/bash".to_string(), "-euo".to_string(), "pipefail".to_string(), "-c".to_string()])
+        .command(vec![
+            "/bin/bash".to_string(),
+            "-euo".to_string(),
+            "pipefail".to_string(),
+            "-c".to_string(),
+        ])
         .args(vec![[
             "echo chowning data directory",
             "chown -R stackable:stackable /stackable/data",

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -10,6 +10,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_kafka_crd::{
     KafkaCluster, KafkaRole, APP_NAME, APP_PORT, METRICS_PORT, SERVER_PROPERTIES_FILE,
 };
+use stackable_operator::k8s_openapi::api::core::v1::SecurityContext;
 use stackable_operator::{
     builder::{ConfigMapBuilder, ContainerBuilder, ObjectMetaBuilder, PodBuilder},
     k8s_openapi::{
@@ -370,6 +371,29 @@ fn build_broker_rolegroup_statefulset(
         }])
         .add_volume_mount("tmp", "/stackable/tmp")
         .build();
+
+    // For most storage classes the mounts will belong to the root user and not be writeable to
+    // other users.
+    // Since kafka runs as the user stackable inside of the container the data directory needs to be
+    // chowned to that user for it to be able to store data there.
+    let mut container_chown = ContainerBuilder::new("chown-data")
+        .image(&image)
+        .command(vec!["/bin/bash".to_string(), "-c".to_string()])
+        .args(vec![[
+            "echo chowning data directory",
+            "chown -R stackable:stackable /stackable/data",
+            "echo chmodding data directory",
+            "chmod -R a=,u=rwX /stackable/data",
+        ]
+        .join(" && ")])
+        .add_volume_mount("data", "/stackable/data")
+        .build();
+
+    container_chown
+        .security_context
+        .get_or_insert_with(SecurityContext::default)
+        .run_as_user = Some(0);
+
     let mut env = broker_config
         .get(&PropertyNameKind::Env)
         .iter()
@@ -516,6 +540,7 @@ fn build_broker_rolegroup_statefulset(
                     .with_label(pod_svc_controller::LABEL_ENABLE, "true")
                 })
                 .add_init_container(container_get_svc)
+                .add_init_container(container_chown)
                 .add_container(container_kafka)
                 .add_container(container_kcat_prober)
                 .add_volume(Volume {

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -378,7 +378,7 @@ fn build_broker_rolegroup_statefulset(
     // chowned to that user for it to be able to store data there.
     let mut container_chown = ContainerBuilder::new("chown-data")
         .image(&image)
-        .command(vec!["/bin/bash".to_string(), "-c".to_string()])
+        .command(vec!["/bin/bash".to_string(), "-euo".to_string(), "pipefail".to_string(), "-c".to_string()])
         .args(vec![[
             "echo chowning data directory",
             "chown -R stackable:stackable /stackable/data",


### PR DESCRIPTION
The default logs.dir for Kafka is moved to a subdirectory of the volume mount, as Kafka is troubled by the presence of the "lost+found" folder which resides in the root dir.

Added an init container to chown the data directory to the Stackable user.

fixes #279

## Description

*Please add a description here. This will become the commit message of the merge request later.*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
