### PR TITLE
[Merged by Bors] - Use opa config from operator rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.10.0` → `0.15.0` ([#346], [#351], [#385]).
 - `--kafka-broker-clusterrole` is now only accepted for the `run` subcommand ([#349]).
 - BREAKING: Adapted the `opa` field in the crd to `opaConfigMapName` and fixed `authorizer.class.name` to `org.openpolicyagent.kafka.OpaAuthorizer` and `opa.authorizer.metrics.enabled` to `true`. Other settings can be changed via `configOverrides` ([#364]).
-- BREAKING: `opaConfigMapName` in CRD adapted to `opa` using the `OpaConfig` from operator-rs ([#385]). 
+- BREAKING: `opaConfigMapName` in CRD adapted to `opa` using the `OpaConfig` from operator-rs ([#385]).
 
 [#346]: https://github.com/stackabletech/kafka-operator/pull/346
 [#347]: https://github.com/stackabletech/kafka-operator/pull/347
@@ -34,7 +34,6 @@ All notable changes to this project will be documented in this file.
 [#256]: https://github.com/stackabletech/kafka-operator/pull/256
 
 ## [0.4.0] - 2021-12-06
-
 
 - `operator-rs` `0.3.0` → `0.4.0` ([#214]).
 - `stackable-opa-crd` `0.4.1` → `0.5.0` ([#214]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `operator-rs` `0.10.0` → `0.13.0` ([#346],[#351]).
+- `operator-rs` `0.10.0` → `0.15.0` ([#346], [#351], [#385]).
 - `--kafka-broker-clusterrole` is now only accepted for the `run` subcommand ([#349]).
 - BREAKING: Adapted the `opa` field in the crd to `opaConfigMapName` and fixed `authorizer.class.name` to `org.openpolicyagent.kafka.OpaAuthorizer` and `opa.authorizer.metrics.enabled` to `true`. Other settings can be changed via `configOverrides` ([#364]).
+- BREAKING: `opaConfigMapName` in CRD adapted to `opa` using the `OpaConfig` from operator-rs ([#385]). 
 
 [#346]: https://github.com/stackabletech/kafka-operator/pull/346
 [#347]: https://github.com/stackabletech/kafka-operator/pull/347
 [#349]: https://github.com/stackabletech/kafka-operator/pull/349
 [#351]: https://github.com/stackabletech/kafka-operator/pull/351
 [#364]: https://github.com/stackabletech/kafka-operator/pull/364
+[#385]: https://github.com/stackabletech/kafka-operator/pull/385
 
 ## [0.5.0] - 2022-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +358,16 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "fancy-regex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "fastrand"
@@ -716,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86835e9147615457c1edc2b11c723acd1d21372e9cefa80a9d2742f6d69042d0"
+checksum = "4dcc72fdf0c491160a34d4a1bfb03f96da8a5054288d61c816d514b5c2fa49ea"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -729,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f8aa916ee8290fbd0af76b3a28093a8786fccb6286902095a5243484447971"
+checksum = "94b01c722d55ffedec74cbc259b4508d8a59bf19540006ec87618f76ab156579"
 dependencies = [
  "base64",
  "bytes",
@@ -757,7 +782,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -765,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da41f98f213796a68fcd4510c88b5fd36de131c1ea30d152474c3f2e1bef1a72"
+checksum = "7dd9e3535777edd122cc26fe3fe6357066b33eff63d8b919862edbe7a956a679"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -783,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6fdc2e1615a3aecd7e90fe4bda3ba32379e38193251d4ddaccba26579fe22"
+checksum = "1322e25c20dd6f18ca6baecc88bb130331e99d988df9d7a9a207f15819e05bff"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -796,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e8bf2258850dbc0a062b561656a1d7020fa8040d552e149f0a0361f0d6794e"
+checksum = "816c8c086f8bbcf9a4db0b7a68db90b784ef6292a57de35c64cccb90d5edfbe5"
 dependencies = [
  "ahash",
  "backoff",
@@ -814,7 +839,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1038,27 +1063,25 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1155,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.3.0"
-source = "git+https://github.com/stackabletech/product-config.git?tag=0.3.0#602e7b8e1c235dd93fb3289662c1200eaa1a83db"
+version = "0.3.1"
+source = "git+https://github.com/stackabletech/product-config.git?tag=0.3.1#40c93e5283beef100c9fecdb6368f1e1480db3e8"
 dependencies = [
+ "fancy-regex",
  "java-properties",
- "regex",
  "schemars",
  "semver",
  "serde",
@@ -1494,7 +1517,7 @@ dependencies = [
  "serde_yaml",
  "snafu",
  "stackable-operator",
- "strum 0.24.0",
+ "strum",
 ]
 
 [[package]]
@@ -1507,7 +1530,7 @@ dependencies = [
  "snafu",
  "stackable-kafka-crd",
  "stackable-operator",
- "strum 0.24.0",
+ "strum",
  "tokio",
  "tracing",
 ]
@@ -1528,8 +1551,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.13.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
+version = "0.15.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.15.0#c7c408d476c0b7ba06833c19e5c9d2aefa5875ae"
 dependencies = [
  "backoff",
  "chrono",
@@ -1549,7 +1572,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum 0.23.0",
+ "strum",
  "thiserror",
  "tokio",
  "tracing",
@@ -1564,33 +1587,11 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-dependencies = [
- "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 dependencies = [
- "strum_macros 0.24.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1750,21 +1751,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
@@ -1773,7 +1759,9 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1796,7 +1784,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2021,6 +2009,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "xml-rs"

--- a/deploy/crd/kafkacluster.crd.yaml
+++ b/deploy/crd/kafkacluster.crd.yaml
@@ -112,9 +112,17 @@ spec:
                 log4j:
                   nullable: true
                   type: string
-                opaConfigMapName:
+                opa:
                   nullable: true
-                  type: string
+                  properties:
+                    configMapName:
+                      type: string
+                    package:
+                      nullable: true
+                      type: string
+                  required:
+                    - configMapName
+                  type: object
                 stopped:
                   nullable: true
                   type: boolean

--- a/deploy/helm/kafka-operator/crds/crds.yaml
+++ b/deploy/helm/kafka-operator/crds/crds.yaml
@@ -114,9 +114,17 @@ spec:
                 log4j:
                   nullable: true
                   type: string
-                opaConfigMapName:
+                opa:
                   nullable: true
-                  type: string
+                  properties:
+                    configMapName:
+                      type: string
+                    package:
+                      nullable: true
+                      type: string
+                  required:
+                    - configMapName
+                  type: object
                 stopped:
                   nullable: true
                   type: boolean

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -115,9 +115,17 @@ spec:
                 log4j:
                   nullable: true
                   type: string
-                opaConfigMapName:
+                opa:
                   nullable: true
-                  type: string
+                  properties:
+                    configMapName:
+                      type: string
+                    package:
+                      nullable: true
+                      type: string
+                  required:
+                    - configMapName
+                  type: object
                 stopped:
                   nullable: true
                   type: boolean

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -29,7 +29,7 @@ To create an Apache Kafka (v3.1.0) cluster named `simple-kafka` assuming that yo
             replicas: 1
     EOF
 
-If you wish to include integration with https://docs.stackable.tech/opa/index.html[Open Policy Agent] and already have an opa cluster, then you can include an `opaConfigMapName` pointing to the cluster:
+If you wish to include integration with https://docs.stackable.tech/opa/index.html[Open Policy Agent] and already have an OPA cluster, then you can include an `opa` field pointing to the OPA cluster discovery `ConfigMap` and the required package. The package is optional and will default to the `metadata.name` field:
 
     cat <<EOF | kubectl apply -f -
     apiVersion: kafka.stackable.tech/v1alpha1
@@ -39,7 +39,9 @@ If you wish to include integration with https://docs.stackable.tech/opa/index.ht
     spec:
       version: 3.1.0
       zookeeperConfigMapName: simple-kafka-znode
-      opaConfigMapName: simple-opa
+      opa:
+        configMapName: simple-opa
+        package: kafka/authz
       brokers:
         roleGroups:
           default:
@@ -56,7 +58,9 @@ You can change some opa cache properties by overriding:
     spec:
       version: 3.1.0
       zookeeperConfigMapName: simple-kafka-znode
-      opaConfigMapName: simple-opa
+      opa:
+        configMapName: simple-opa
+        package: kafka/authz
       brokers:
         configOverrides:
           server.properties:

--- a/examples/logging/simple-kafka-cluster-opa-log4j.yaml
+++ b/examples/logging/simple-kafka-cluster-opa-log4j.yaml
@@ -55,7 +55,9 @@ metadata:
 spec:
   version: 3.1.0
   zookeeperConfigMapName: simple-kafka-znode
-  opaConfigMapName: simple-opa
+  opa:
+    configMapName: simple-opa
+    package: kafka/authz
   log4j: |-
     log4j.rootLogger=INFO, stdout, kafkaAppender
 

--- a/examples/opa/simple-kafka-cluster-opa-allow-all.yaml
+++ b/examples/opa/simple-kafka-cluster-opa-allow-all.yaml
@@ -55,7 +55,9 @@ metadata:
 spec:
   version: 3.1.0
   zookeeperConfigMapName: simple-kafka-znode
-  opaConfigMapName: simple-opa
+  opa:
+    configMapName: simple-opa
+    package: kafka/authz
   brokers:
     configOverrides:
       server.properties:

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stackabletech/kafka-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 
 semver = "1.0.6"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, Snafu};
 use stackable_operator::kube::runtime::reflector::ObjectRef;
 use stackable_operator::kube::CustomResource;
+use stackable_operator::opa::OpaConfig;
 use stackable_operator::product_config_utils::{ConfigError, Configuration};
 use stackable_operator::role_utils::Role;
 use stackable_operator::role_utils::RoleGroupRef;
@@ -34,7 +35,7 @@ pub struct KafkaClusterSpec {
     pub version: Option<String>,
     pub brokers: Option<Role<KafkaConfig>>,
     pub zookeeper_config_map_name: String,
-    pub opa_config_map_name: Option<String>,
+    pub opa: Option<OpaConfig>,
     pub log4j: Option<String>,
     pub stopped: Option<bool>,
 }
@@ -154,7 +155,7 @@ impl Configuration for KafkaConfig {
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
         let mut config = BTreeMap::new();
 
-        if resource.spec.opa_config_map_name.is_some() && file == SERVER_PROPERTIES_FILE {
+        if resource.spec.opa.is_some() && file == SERVER_PROPERTIES_FILE {
             config.insert(
                 "authorizer.class.name".to_string(),
                 Some("org.openpolicyagent.kafka.OpaAuthorizer".to_string()),

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.6.0-nightly"
 [dependencies]
 stackable-kafka-crd = { path = "../crd" }
 stackable-kafka-operator = { path = "../operator" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 
 clap = { version = "3.1.6", features = ["derive", "env"] }
 serde_yaml = "0.8.23"
@@ -20,11 +20,9 @@ tracing = "0.1.32"
 
 [build-dependencies]
 built = { version = "0.5.1", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 stackable-kafka-crd = { path = "../crd" }
 
 [[bin]]
 name = "stackable-kafka-operator"
 path = "src/stackable-kafka-operator.rs"
-
-[features]

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.6.0-nightly"
 
 [dependencies]
 stackable-kafka-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -11,6 +11,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_kafka_crd::{
     KafkaCluster, KafkaRole, APP_NAME, APP_PORT, METRICS_PORT, SERVER_PROPERTIES_FILE,
 };
+use stackable_operator::opa::OpaApiVersion;
 use stackable_operator::{
     builder::{ConfigMapBuilder, ContainerBuilder, ObjectMetaBuilder, PodBuilder},
     k8s_openapi::{
@@ -134,6 +135,10 @@ pub enum Error {
     InvalidServiceAccount {
         source: utils::NamespaceMismatchError,
     },
+    #[snafu(display("invalid OpaConfig"))]
+    InvalidOpaConfig {
+        source: stackable_operator::error::Error,
+    },
 }
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -202,6 +207,25 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Context<Ctx>) -> Res
         )
         .await
         .context(ApplyRoleRoleBindingSnafu)?;
+
+    // Assemble the OPA connection string from the discovery and the given path if provided
+    // Will be passed as --override parameter in the cli in the state ful set
+    let opa_connect = if let Some(opa_spec) = &kafka.spec.opa {
+        Some(
+            opa_spec
+                .full_document_url_from_config_map(
+                    client,
+                    &*kafka,
+                    Some("allow"),
+                    OpaApiVersion::V1,
+                )
+                .await
+                .context(InvalidOpaConfigSnafu)?,
+        )
+    } else {
+        None
+    };
+
     for (rolegroup_name, rolegroup_config) in role_broker_config.iter() {
         let rolegroup = kafka.broker_rolegroup_ref(rolegroup_name);
 
@@ -212,6 +236,7 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Context<Ctx>) -> Res
             &kafka,
             rolegroup_config,
             &broker_role_serviceaccount_ref,
+            opa_connect.as_deref(),
         )?;
         client
             .apply_patch(FIELD_MANAGER_SCOPE, &rg_service, &rg_service)
@@ -423,6 +448,7 @@ fn build_broker_rolegroup_statefulset(
     kafka: &KafkaCluster,
     broker_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
     serviceaccount: &ObjectRef<ServiceAccount>,
+    opa_connect_string: Option<&str>,
 ) -> Result<StatefulSet> {
     let role = kafka.spec.brokers.as_ref().context(NoBrokerRoleSnafu)?;
     let rolegroup = role
@@ -512,24 +538,7 @@ fn build_broker_rolegroup_statefulset(
         }),
         ..EnvVar::default()
     });
-    let opa_url_env_var = if let Some(opa_config_map_name) = &kafka.spec.opa_config_map_name {
-        let env_var = "OPA";
-        env.push(EnvVar {
-            name: env_var.to_string(),
-            value_from: Some(EnvVarSource {
-                config_map_key_ref: Some(ConfigMapKeySelector {
-                    name: Some(opa_config_map_name.to_string()),
-                    key: "OPA".to_string(),
-                    ..ConfigMapKeySelector::default()
-                }),
-                ..EnvVarSource::default()
-            }),
-            ..EnvVar::default()
-        });
-        Some(env_var)
-    } else {
-        None
-    };
+
     env.push(EnvVar {
         name: "NODE".to_string(),
         value_from: Some(EnvVarSource {
@@ -557,9 +566,10 @@ fn build_broker_rolegroup_statefulset(
     let zookeeper_override = "--override \"zookeeper.connect=$ZOOKEEPER\"";
     let advertised_listeners_override =
         "--override \"advertised.listeners=PLAINTEXT://$NODE:$(cat /stackable/tmp/nodeport)\"";
-    let opa_url_override = &opa_url_env_var.map_or("", |_| {
-        "--override \"opa.authorizer.url=${OPA}v1/data/kafka/authz/allow\""
+    let opa_url_override = opa_connect_string.map_or("".to_string(), |opa| {
+        format!("--override \"opa.authorizer.url={}\"", opa)
     });
+
     let container_kafka = ContainerBuilder::new("kafka")
         .image(image)
         .args(vec![
@@ -570,7 +580,7 @@ fn build_broker_rolegroup_statefulset(
                 &format!("/stackable/config/{}", SERVER_PROPERTIES_FILE),
                 zookeeper_override,
                 advertised_listeners_override,
-                opa_url_override,
+                &opa_url_override,
             ]
             .join(" "),
         ])


### PR DESCRIPTION
## Description

- added OpaConfig from operator-rs (Breaking CRD change)
- updated operator-rs to 0.15.0
- adapted docs

closes https://github.com/stackabletech/kafka-operator/issues/372

Integration tests do not need to be adapted, there is no reference to the optional OPA stuff.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
