### PR TITLE
[Merged by Bors] - Migrate integration tests

### DIFF
--- a/.ci/integration-tests/aws-eks/cluster.yaml
+++ b/.ci/integration-tests/aws-eks/cluster.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: aws-eks
+metadata:
+  name: kafka-operator-integration-tests
+  description: "Cluster for Kafka Operator Integration Tests (AWS EKS)"
+publicKeys: []
+spec:
+  region: "eu-central-1"
+  awsInstanceType: "t2.medium"
+  versions:
+    _-operator: NIGHTLY
+    kafka-operator: "$KAFKA_OPERATOR_VERSION"
+  node_count: 3

--- a/.ci/integration-tests/aws-eks/test.sh
+++ b/.ci/integration-tests/aws-eks/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone -b "$GIT_BRANCH" https://github.com/stackabletech/kafka-operator.git
+(cd kafka-operator/ && ./scripts/run_tests.sh --parallel 1)
+exit_code=$?
+./operator-logs.sh kafka > /target/kafka-operator.log
+exit $exit_code

--- a/.ci/integration-tests/azure-aks/cluster.yaml
+++ b/.ci/integration-tests/azure-aks/cluster.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: azure-aks
+metadata:
+  name: kafka-operator-integration-tests
+  description: "Cluster for Kafka Operator Integration Tests (Azure AKS)"
+publicKeys: []
+spec:
+  versions:
+    _-operator: NIGHTLY
+    kafka-operator: "$KAFKA_OPERATOR_VERSION"
+  node_count: 3

--- a/.ci/integration-tests/azure-aks/test.sh
+++ b/.ci/integration-tests/azure-aks/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone -b "$GIT_BRANCH" https://github.com/stackabletech/kafka-operator.git
+(cd kafka-operator/ && ./scripts/run_tests.sh --parallel 1)
+exit_code=$?
+./operator-logs.sh kafka > /target/kafka-operator.log
+exit $exit_code

--- a/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata:
+  name: kafka-operator-integration-tests
+  description: "Cluster for Kafka Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  k8sVersion: "$K8S_VERSION"
+  wireguard: false
+  versions:
+    _-operator: NIGHTLY
+    kafka-operator: "$KAFKA_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3

--- a/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone -b "$GIT_BRANCH" https://github.com/stackabletech/kafka-operator.git
+(cd kafka-operator/ && ./scripts/run_tests.sh --parallel 1)
+exit_code=$?
+./operator-logs.sh kafka > /target/kafka-operator.log
+exit $exit_code

--- a/.ci/integration-tests/ionos-k8s/cluster.yaml
+++ b/.ci/integration-tests/ionos-k8s/cluster.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: ionos-k8s
+metadata:
+  name: kafka-operator-integration-tests
+  description: "Cluster for Kafka Operator Integration Tests (IONOS Cloud managed K8s)"
+domain: stackable.test
+publicKeys: []
+spec:
+  region: de/fra
+  versions:
+    _-operator: NIGHTLY
+    kafka-operator: "$KAFKA_OPERATOR_VERSION"
+  node_count: 3

--- a/.ci/integration-tests/ionos-k8s/test.sh
+++ b/.ci/integration-tests/ionos-k8s/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone -b "$GIT_BRANCH" https://github.com/stackabletech/kafka-operator.git
+(cd kafka-operator/ && ./scripts/run_tests.sh --parallel 1)
+exit_code=$?
+./operator-logs.sh kafka > /target/kafka-operator.log
+exit $exit_code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,3 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-
-  - repo: https://github.com/PyCQA/pylint
-    rev: v2.13.9
-    hooks:
-      - id: pylint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   a single namespace to watch ([#351]).
 - Optional CRD field `log4j` to adapt the `log4j.properties` ([#364]).
 - PVCs for data storage, cpu and memory limits are now configurable ([#405]).
+- Moved tests from integration tests repo to operator repo ([#409]).
 
 ### Changed
 
@@ -19,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - `--kafka-broker-clusterrole` is now only accepted for the `run` subcommand ([#349]).
 - BREAKING: Adapted the `opa` field in the crd to `opaConfigMapName` and fixed `authorizer.class.name` to `org.openpolicyagent.kafka.OpaAuthorizer` and `opa.authorizer.metrics.enabled` to `true`. Other settings can be changed via `configOverrides` ([#364]).
 - BREAKING: `opaConfigMapName` in CRD adapted to `opa` using the `OpaConfig` from operator-rs ([#385]).
+- BREAKING: Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so version: 3.1.0 becomes (for example) version: 3.1.0-stackable0 ([#409])
 
 [#346]: https://github.com/stackabletech/kafka-operator/pull/346
 [#347]: https://github.com/stackabletech/kafka-operator/pull/347
@@ -27,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#364]: https://github.com/stackabletech/kafka-operator/pull/364
 [#385]: https://github.com/stackabletech/kafka-operator/pull/385
 [#405]: https://github.com/stackabletech/kafka-operator/pull/405
+[#409]: https://github.com/stackabletech/kafka-operator/pull/409
 
 ## [0.5.0] - 2022-02-14
 

--- a/docs/modules/ROOT/pages/config_properties.adoc
+++ b/docs/modules/ROOT/pages/config_properties.adoc
@@ -7,7 +7,7 @@ The cluster can be configured via a YAML file. This custom resource specifies th
     metadata:
       name: simple-kafka
     spec:
-      version: 3.1.0
+      version: 3.1.0-stackable0
       zookeeperConfigMapName: simple-kafka-znode
       opa:
         configMapName: simple-opa

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -21,7 +21,7 @@ To create an Apache Kafka (v3.1.0) cluster named `simple-kafka` assuming that yo
     metadata:
       name: simple-kafka
     spec:
-      version: 3.1.0
+      version: 3.1.0-stackable0
       zookeeperConfigMapName: simple-kafka-znode
       brokers:
         roleGroups:
@@ -37,7 +37,7 @@ If you wish to include integration with https://docs.stackable.tech/opa/index.ht
     metadata:
       name: simple-kafka
     spec:
-      version: 3.1.0
+      version: 3.1.0-stackable0
       zookeeperConfigMapName: simple-kafka-znode
       opa:
         configMapName: simple-opa
@@ -56,7 +56,7 @@ You can change some opa cache properties by overriding:
     metadata:
       name: simple-kafka
     spec:
-      version: 3.1.0
+      version: 3.1.0-stackable0
       zookeeperConfigMapName: simple-kafka-znode
       opa:
         configMapName: simple-opa
@@ -91,7 +91,7 @@ kind: KafkaCluster
 metadata:
   name: simple-kafka
 spec:
-  version: 3.1.0
+  version: 3.1.0-stackable0
   zookeeperConfigMapName: simple-kafka-znode
   log4j: |-
     log4j.rootLogger=INFO, stdout, kafkaAppender

--- a/examples/logging/simple-kafka-cluster-opa-log4j.yaml
+++ b/examples/logging/simple-kafka-cluster-opa-log4j.yaml
@@ -53,7 +53,7 @@ kind: KafkaCluster
 metadata:
   name: simple-kafka
 spec:
-  version: 3.1.0
+  version: 3.1.0-stackable0
   zookeeperConfigMapName: simple-kafka-znode
   opa:
     configMapName: simple-opa

--- a/examples/opa/simple-kafka-cluster-opa-allow-all.yaml
+++ b/examples/opa/simple-kafka-cluster-opa-allow-all.yaml
@@ -53,7 +53,7 @@ kind: KafkaCluster
 metadata:
   name: simple-kafka
 spec:
-  version: 3.1.0
+  version: 3.1.0-stackable0
   zookeeperConfigMapName: simple-kafka-znode
   opa:
     configMapName: simple-opa

--- a/examples/simple-kafka-cluster.yaml
+++ b/examples/simple-kafka-cluster.yaml
@@ -27,7 +27,7 @@ kind: KafkaCluster
 metadata:
   name: simple-kafka
 spec:
-  version: 3.1.0
+  version: 3.1.0-stackable0
   zookeeperConfigMapName: simple-kafka-znode
   brokers:
     config:

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -34,7 +34,7 @@ const JVM_HEAP_FACTOR: f32 = 0.8;
 #[derive(Snafu, Debug)]
 pub enum Error {
     #[snafu(display("could not parse product version from image: [{image_version}]. Expected format e.g. [2.8.0-stackable0.1.0]"))]
-    TrinoProductVersion { image_version: String },
+    KafkaProductVersion { image_version: String },
     #[snafu(display("object has no namespace associated"))]
     NoNamespace,
     #[snafu(display("object defines no version"))]
@@ -196,10 +196,8 @@ impl KafkaCluster {
         let image_version = self.image_version()?;
         image_version
             .split('-')
-            .collect::<Vec<_>>()
-            .first()
-            .cloned()
-            .with_context(|| TrinoProductVersionSnafu {
+            .next()
+            .with_context(|| KafkaProductVersionSnafu {
                 image_version: image_version.to_string(),
             })
     }

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -15,6 +15,6 @@ futures = "0.3.21"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 strum = { version = "0.24.0", features = ["derive"] }
-tokio = { version = "1.17.0", features = ["macros"] }
+tokio = { version = "1.18.2", features = ["macros"] }
 tracing = "0.1.34"
 snafu = "0.7.1"

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -459,10 +459,7 @@ fn build_broker_rolegroup_statefulset(
             rolegroup: rolegroup_ref.clone(),
         })?;
     let kafka_version = kafka_version(kafka)?;
-    let image = format!(
-        "docker.stackable.tech/stackable/kafka:{}-stackable0",
-        kafka_version
-    );
+    let image = format!("docker.stackable.tech/stackable/kafka:{}", kafka_version);
 
     let container_get_svc = ContainerBuilder::new("get-svc")
         .image("bitnami/kubectl:1.21.1")

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -140,6 +140,8 @@ pub enum Error {
     InvalidJavaHeapConfig {
         source: stackable_operator::error::Error,
     },
+    #[snafu(display("failed to parse Kafka version/image"))]
+    KafkaVersionParseFailure { source: stackable_kafka_crd::Error },
 }
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -154,7 +156,9 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Context<Ctx>) -> Res
     let client = &ctx.get_ref().client;
 
     let validated_config = validate_all_roles_and_groups_config(
-        kafka_version(&kafka)?,
+        kafka
+            .product_version()
+            .context(KafkaVersionParseFailureSnafu)?,
         &transform_all_roles_to_config(
             &*kafka,
             [(
@@ -285,7 +289,15 @@ pub fn build_broker_role_service(kafka: &KafkaCluster) -> Result<Service> {
             .name(&role_svc_name)
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
-            .with_recommended_labels(kafka, APP_NAME, kafka_version(kafka)?, &role_name, "global")
+            .with_recommended_labels(
+                kafka,
+                APP_NAME,
+                kafka
+                    .image_version()
+                    .context(KafkaVersionParseFailureSnafu)?,
+                &role_name,
+                "global",
+            )
             .build(),
         spec: Some(ServiceSpec {
             ports: Some(vec![ServicePort {
@@ -314,7 +326,15 @@ fn build_broker_role_serviceaccount(
             .name(&sa_name)
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
-            .with_recommended_labels(kafka, APP_NAME, kafka_version(kafka)?, &role_name, "global")
+            .with_recommended_labels(
+                kafka,
+                APP_NAME,
+                kafka
+                    .image_version()
+                    .context(KafkaVersionParseFailureSnafu)?,
+                &role_name,
+                "global",
+            )
             .build(),
         ..ServiceAccount::default()
     };
@@ -325,7 +345,15 @@ fn build_broker_role_serviceaccount(
             .name(binding_name)
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
-            .with_recommended_labels(kafka, APP_NAME, kafka_version(kafka)?, &role_name, "global")
+            .with_recommended_labels(
+                kafka,
+                APP_NAME,
+                kafka
+                    .image_version()
+                    .context(KafkaVersionParseFailureSnafu)?,
+                &role_name,
+                "global",
+            )
             .build(),
         role_ref: RoleRef {
             api_group: ClusterRole::GROUP.to_string(),
@@ -366,7 +394,9 @@ fn build_broker_rolegroup_config_map(
                 .with_recommended_labels(
                     kafka,
                     APP_NAME,
-                    kafka_version(kafka)?,
+                    kafka
+                        .image_version()
+                        .context(KafkaVersionParseFailureSnafu)?,
                     &rolegroup.role,
                     &rolegroup.role_group,
                 )
@@ -406,7 +436,9 @@ fn build_broker_rolegroup_service(
             .with_recommended_labels(
                 kafka,
                 APP_NAME,
-                kafka_version(kafka)?,
+                kafka
+                    .image_version()
+                    .context(KafkaVersionParseFailureSnafu)?,
                 &rolegroup.role,
                 &rolegroup.role_group,
             )
@@ -458,7 +490,9 @@ fn build_broker_rolegroup_statefulset(
         .with_context(|| RoleGroupNotFoundSnafu {
             rolegroup: rolegroup_ref.clone(),
         })?;
-    let kafka_version = kafka_version(kafka)?;
+    let kafka_version = kafka
+        .image_version()
+        .context(KafkaVersionParseFailureSnafu)?;
     let image = format!("docker.stackable.tech/stackable/kafka:{}", kafka_version);
 
     let container_get_svc = ContainerBuilder::new("get-svc")
@@ -705,14 +739,6 @@ fn build_broker_rolegroup_statefulset(
         }),
         status: None,
     })
-}
-
-pub fn kafka_version(kafka: &KafkaCluster) -> Result<&str> {
-    kafka
-        .spec
-        .version
-        .as_deref()
-        .context(ObjectHasNoVersionSnafu)
 }
 
 pub fn error_policy(_error: &Error, _ctx: Context<Ctx>) -> Action {

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -490,10 +490,10 @@ fn build_broker_rolegroup_statefulset(
         .with_context(|| RoleGroupNotFoundSnafu {
             rolegroup: rolegroup_ref.clone(),
         })?;
-    let kafka_version = kafka
+    let image_version = kafka
         .image_version()
         .context(KafkaVersionParseFailureSnafu)?;
-    let image = format!("docker.stackable.tech/stackable/kafka:{}", kafka_version);
+    let image = format!("docker.stackable.tech/stackable/kafka:{}", image_version);
 
     let container_get_svc = ContainerBuilder::new("get-svc")
         .image("bitnami/kubectl:1.21.1")
@@ -669,7 +669,7 @@ fn build_broker_rolegroup_statefulset(
             m.with_recommended_labels(
                 kafka,
                 APP_NAME,
-                kafka_version,
+                image_version,
                 &rolegroup_ref.role,
                 &rolegroup_ref.role_group,
             )
@@ -711,7 +711,7 @@ fn build_broker_rolegroup_statefulset(
             .with_recommended_labels(
                 kafka,
                 APP_NAME,
-                kafka_version,
+                image_version,
                 &rolegroup_ref.role,
                 &rolegroup_ref.role_group,
             )

--- a/tests/templates/kuttl/smoke/00-assert.yaml
+++ b/tests/templates/kuttl/smoke/00-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-kafka-zk
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-zk-server-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/smoke/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-install-zk.yaml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-kafka-zk
+timeout: 300
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperCluster
+metadata:
+  name: kafka-zk
+spec:
+  servers:
+    roleGroups:
+      default:
+        replicas: 1
+        config:
+          myidOffset: 10
+  version: {{ test_scenario['values']['zookeeper'] }}
+  stopped: false

--- a/tests/templates/kuttl/smoke/01-assert.yaml
+++ b/tests/templates/kuttl/smoke/01-assert.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-kafka-zk
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: simple-kafka-broker-default
+spec:
+  template:
+    spec:
+      containers:
+        - name: kafka
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 1Gi
+        - name: kcat-prober
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: log-dirs-simple-kafka-broker-default-0
+status:
+  capacity:
+    storage: 2Gi
+  phase: Bound

--- a/tests/templates/kuttl/smoke/01-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/smoke/01-install-kafka.yaml.j2
@@ -1,0 +1,28 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-kafka
+timeout: 300
+---
+apiVersion: kafka.stackable.tech/v1alpha1
+kind: KafkaCluster
+metadata:
+  name: simple-kafka
+spec:
+  version: {{ test_scenario['values']['kafka'] }}
+  zookeeperConfigMapName: kafka-zk
+  brokers:
+    config:
+      resources:
+        storage:
+          logDirs:
+            capacity: '2Gi'
+        cpu:
+          max: '500m'
+          min: '250m'
+        memory:
+          limit: '1Gi'
+    roleGroups:
+      default:
+        replicas: 1

--- a/tests/templates/kuttl/smoke/02-assert.yaml
+++ b/tests/templates/kuttl/smoke/02-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-test-container
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: python
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/smoke/02-install-test-container.yaml
+++ b/tests/templates/kuttl/smoke/02-install-test-container.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-test-container
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: python
+  labels:
+    app: python
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: python
+  template:
+    metadata:
+      labels:
+        app: python
+    spec:
+      containers:
+        - name: webhdfs
+          image: python:3.10-slim
+          stdin: true
+          tty: true

--- a/tests/templates/kuttl/smoke/03-assert.yaml
+++ b/tests/templates/kuttl/smoke/03-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: metrics
+commands:
+  - script: kubectl exec -n $NAMESPACE python-0 -- python /tmp/metrics.py
+  - script: kubectl exec -n $NAMESPACE simple-kafka-broker-default-0 -- /tmp/test_heap.sh

--- a/tests/templates/kuttl/smoke/03-prepare-test.yaml
+++ b/tests/templates/kuttl/smoke/03-prepare-test.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: kafka-tests
+commands:
+  - script: kubectl cp -n $NAMESPACE ./requirements.txt python-0:/tmp
+  - script: kubectl cp -n $NAMESPACE ./metrics.py python-0:/tmp
+  - script: kubectl exec -n $NAMESPACE python-0 -- pip install --user -r /tmp/requirements.txt
+  - script: kubectl cp -n $NAMESPACE ./test_heap.sh simple-kafka-broker-default-0:/tmp

--- a/tests/templates/kuttl/smoke/metrics.py
+++ b/tests/templates/kuttl/smoke/metrics.py
@@ -1,0 +1,15 @@
+import sys
+import logging
+import requests
+
+if __name__ == "__main__":
+    result = 0
+
+    LOG_LEVEL = 'DEBUG'  # if args.debug else 'INFO'
+    logging.basicConfig(level=LOG_LEVEL, format='%(asctime)s %(levelname)s: %(message)s', stream=sys.stdout)
+
+    http_code = requests.get("http://simple-kafka-broker-default:9606").status_code
+    if http_code != 200:
+        result = 1
+
+    sys.exit(result)

--- a/tests/templates/kuttl/smoke/requirements.txt
+++ b/tests/templates/kuttl/smoke/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2021.10.8
+charset-normalizer==2.0.12
+idna==3.3
+requests==2.27.1
+urllib3==1.26.9

--- a/tests/templates/kuttl/smoke/test_heap.sh
+++ b/tests/templates/kuttl/smoke/test_heap.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Usage: test_heap.sh
+
+# 1Gi * 0.8 -> 819
+EXPECTED_HEAP=-"Xmx819m"
+
+# Check if ZK_SERVER_HEAP is set to the correct calculated value
+if [[ $KAFKA_HEAP_OPTS == "$EXPECTED_HEAP" ]]
+then
+  echo "[SUCCESS] KAFKA_HEAP_OPTS set to $EXPECTED_HEAP"
+else
+  echo "[ERROR] KAFKA_HEAP_OPTS not set or set with wrong value: $ZK_SERVER_HEAP"
+  exit 1
+fi
+
+echo "[SUCCESS] All heap settings tests successful!"

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/00-assert.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/00-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-zk-server-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/00-install-zk.yaml.j2
@@ -1,0 +1,18 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 300
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperCluster
+metadata:
+  name: kafka-zk
+spec:
+  servers:
+    roleGroups:
+      default:
+        replicas: 1
+        config:
+          myidOffset: 10
+  version: {{ test_scenario['values']['zookeeper'] }}
+  stopped: false

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/01-assert.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/01-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: simple-kafka-broker-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/01-install-kafka.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/01-install-kafka.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 300
+---
+apiVersion: kafka.stackable.tech/v1alpha1
+kind: KafkaCluster
+metadata:
+  name: simple-kafka
+spec:
+  version: 2.8.1-stackable0
+  zookeeperConfigMapName: kafka-zk
+  brokers:
+    roleGroups:
+      default:
+        replicas: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/02-assert.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/02-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: write-data
+status:
+  succeeded: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/02-write-data.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/02-write-data.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 300
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: write-data
+spec:
+  template:
+    spec:
+      containers:
+        - name: write-data
+          image: edenhill/kcat:1.7.1
+          command: [sh, -euo, pipefail, -c]
+          args:
+            - |
+              echo "message written before upgrade" > message
+              kcat -b $KAFKA -t upgrade-test-data -P message
+          env:
+            - name: KAFKA
+              valueFrom:
+                configMapKeyRef:
+                  name: simple-kafka
+                  key: KAFKA
+      restartPolicy: Never

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/03-assert.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/03-assert.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: simple-kafka-broker-default
+  labels:
+    app.kubernetes.io/version: 3.1.0
+status:
+  readyReplicas: 1
+  replicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/03-assert.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/03-assert.yaml
@@ -8,7 +8,7 @@ kind: StatefulSet
 metadata:
   name: simple-kafka-broker-default
   labels:
-    app.kubernetes.io/version: 3.1.0
+    app.kubernetes.io/version: 3.1.0-stackable0
 status:
   readyReplicas: 1
   replicas: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/03-upgrade-kafka.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/03-upgrade-kafka.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 300
+---
+apiVersion: kafka.stackable.tech/v1alpha1
+kind: KafkaCluster
+metadata:
+  name: simple-kafka
+spec:
+  version: 3.1.0-stackable0
+  zookeeperConfigMapName: kafka-zk
+  brokers:
+    roleGroups:
+      default:
+        replicas: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/04-assert.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/04-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: read-data
+status:
+  succeeded: 1

--- a/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/04-read-data.yaml
+++ b/tests/templates/kuttl/upgrade-2.8.1-to-3.1.0/04-read-data.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 300
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: read-data
+spec:
+  template:
+    spec:
+      containers:
+        - name: read-data
+          image: edenhill/kcat:1.7.1
+          command: [sh, -euo, pipefail, -c]
+          args:
+            - |
+              echo "message written after upgrade" > message
+              kcat -b $KAFKA -t upgrade-test-data -P message
+
+              echo "message written before upgrade" > expected-messages
+              echo >> expected-messages
+              cat message >> expected-messages
+              echo >> expected-messages
+              kcat -b $KAFKA -t upgrade-test-data -C -e > read-messages
+              diff read-messages expected-messages
+              cmp read-messages expected-messages
+          env:
+            - name: KAFKA
+              valueFrom:
+                configMapKeyRef:
+                  name: simple-kafka
+                  key: KAFKA
+      restartPolicy: Never

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,11 +2,13 @@
 dimensions:
   - name: kafka
     values:
-      - 2.7.1-scala2.13-opa_authorizer1.4.0-stackable0.5.0
-      - 2.8.1-scala2.13-opa_authorizer1.4.0-stackable0.5.0
-      - 3.1.0-scala2.13-opa_authorizer1.4.0-stackable0.5.0
+      - 2.7.1-stackable0
+      - 2.8.1-stackable0
+      - 3.1.0-stackable0
   - name: zookeeper
     values:
+      - 3.6.3-stackable0.7.1
+      - 3.7.0-stackable0.7.1
       - 3.8.0-stackable0.7.1
 tests:
   - name: smoke

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -15,3 +15,6 @@ tests:
     dimensions:
       - kafka
       - zookeeper
+  - name: upgrade-2.8.1-to-3.1.0
+    dimensions:
+      - zookeeper

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -1,0 +1,15 @@
+---
+dimensions:
+  - name: kafka
+    values:
+      - 2.7.1-scala2.13-opa_authorizer1.4.0-stackable0.5.0
+      - 2.8.1-scala2.13-opa_authorizer1.4.0-stackable0.5.0
+      - 3.1.0-scala2.13-opa_authorizer1.4.0-stackable0.5.0
+  - name: zookeeper
+    values:
+      - 3.8.0-stackable0.7.1
+tests:
+  - name: smoke
+    dimensions:
+      - kafka
+      - zookeeper


### PR DESCRIPTION
# Description

- Moved tests to operator repo
- Adapted to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html)

Currently versions are provided as e.g. `3.1.0-stackable0` instead of the a fully qualified one like 
`3.1.0-scala2.13-opa_authorizer1.4.0-stackable0.5.0` which is not accepted by the product config semver crate.

Removed from integrations tests repo here: https://github.com/stackabletech/integration-tests/pull/248

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
