### PR TITLE
Remove kcat readiness probe and kcat container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `TCPSocketAction` startup probe ([#459]).
+
 ### Changed
 
 - operator-rs: 0.21.1 -> 0.22.0 ([#430]).
 - Include chart name when installing with a custom release name ([#429], [#431]).
-- Kafka init container now uses Stackable tools rather than Bitnami kubectl ([#434])
+- Kafka init container now uses Stackable tools rather than Bitnami kubectl ([#434]).
+- Removed kcat container and readiness probe. The readiness probe is now executed directly from the Kafka container using the `kafka-broker-api-versions.sh` script ([#459]).
 
 [#429]: https://github.com/stackabletech/kafka-operator/pull/429
 [#430]: https://github.com/stackabletech/kafka-operator/pull/430
 [#431]: https://github.com/stackabletech/kafka-operator/pull/431
 [#434]: https://github.com/stackabletech/kafka-operator/pull/434
+[#459]: https://github.com/stackabletech/kafka-operator/pull/459
 
 ## [0.6.0] - 2022-06-30
 

--- a/tests/templates/kuttl/smoke/01-assert.yaml
+++ b/tests/templates/kuttl/smoke/01-assert.yaml
@@ -21,7 +21,6 @@ spec:
             requests:
               cpu: 250m
               memory: 1Gi
-        - name: kcat-prober
 status:
   readyReplicas: 1
   replicas: 1


### PR DESCRIPTION
# Description

- Removed kcat container and readiness probe
- Added readiness probe to kafka container via `kafka-broker-api-versions.sh` script
- Added startup probe via `TCPSocketAction`

fixes https://github.com/stackabletech/kafka-operator/issues/454

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
