### PR TITLE
[Merged by Bors] - Increase TLS test script timeout

### DIFF
--- a/tests/templates/kuttl/tls/30-assert.yaml.j2
+++ b/tests/templates/kuttl/tls/30-assert.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: test-tls
+timeout: 300
 commands:
 {% if test_scenario['values']['use-client-auth-tls'] == 'true' %}
   - script: kubectl exec -n $NAMESPACE test-kafka-broker-default-0 -- /tmp/test_client_auth_tls.sh $NAMESPACE


### PR DESCRIPTION
# Description

Increased the TLS test script timeout which defaulted to 30s and was not enough (kafka-topic.sh does not return very quickly if you test with wrong certificates). This should hopefully fix the Kafka tests.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
