### PR TITLE
[Merged by Bors] - Upgrade stackable-operator to version 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ All notable changes to this project will be documented in this file.
 - Support for Kafka 3.3.1 ([#492])
 - Orphaned resources are deleted ([#495])
 
+### Changed
+
+- Role and rolegroup configurations are merged correctly ([#499]).
+- operator-rs: 0.22.0 -> 0.26.0 ([#495], [#499]).
+
 [#485]: https://github.com/stackabletech/kafka-operator/pull/485
 [#492]: https://github.com/stackabletech/kafka-operator/pull/492
 [#495]: https://github.com/stackabletech/kafka-operator/pull/495
+[#499]: https://github.com/stackabletech/kafka-operator/pull/499
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,8 +1711,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.25.3"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=main#6d12c3c82cb0137dd9a356c9d5facd3359a03471"
+version = "0.26.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.26.0#420ff75a5d6f689ccd74e0a84127836e28d4dc05"
 dependencies = [
  "chrono",
  "clap",
@@ -1745,8 +1745,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.25.3"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=main#6d12c3c82cb0137dd9a356c9d5facd3359a03471"
+version = "0.26.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.26.0#420ff75a5d6f689ccd74e0a84127836e28d4dc05"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,11 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -823,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
  "base64",
  "bytes",
@@ -838,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
+checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -851,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
+checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
 dependencies = [
  "base64",
  "bytes",
@@ -888,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
+checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -906,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
+checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -919,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdcf5a20f968768e342ef1a457491bb5661fccd81119666d626c57500b16d99"
+checksum = "7769af142ee2e46bfa44bd393cf7f40b9d8b80d2e11f6317399551ed17760beb"
 dependencies = [
  "ahash",
  "backoff",
@@ -1711,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.25.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.25.3#406c2fb62144e834981fdd89ed7203c10c0a9e5e"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=main#6d12c3c82cb0137dd9a356c9d5facd3359a03471"
 dependencies = [
  "chrono",
  "clap",
@@ -1732,6 +1733,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.13",
+ "snafu",
  "stackable-operator-derive",
  "strum",
  "thiserror",
@@ -1744,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.25.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.25.3#406c2fb62144e834981fdd89ed7203c10c0a9e5e"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=main#6d12c3c82cb0137dd9a356c9d5facd3359a03471"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,3 @@
 members = [
     "rust/crd", "rust/operator", "rust/operator-binary"
 ]
-
-[patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 members = [
     "rust/crd", "rust/operator", "rust/operator-binary"
 ]
+
+[patch."https://github.com/stackabletech/operator-rs.git"]
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.8.0-nightly"
 publish = false
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.3" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.26.0" }
 
 semver = "1.0.14"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -2,11 +2,17 @@ pub mod listener;
 
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, Snafu};
+use stackable_operator::commons::resources::{
+    CpuLimitsFragment, MemoryLimitsFragment, NoRuntimeLimitsFragment, PvcConfigFragment,
+    ResourcesFragment,
+};
+use stackable_operator::config::fragment::{Fragment, ValidationError};
 use stackable_operator::memory::to_java_heap;
+use stackable_operator::role_utils::RoleGroup;
 use stackable_operator::{
     commons::{
         opa::OpaConfig,
-        resources::{CpuLimits, MemoryLimits, NoRuntimeLimits, PvcConfig, Resources},
+        resources::{NoRuntimeLimits, PvcConfig, Resources},
     },
     config::merge::Merge,
     error::OperatorResult,
@@ -95,6 +101,11 @@ pub enum Error {
     NoNamespace,
     #[snafu(display("object defines no version"))]
     ObjectHasNoVersion,
+    #[snafu(display("failed to validate config of rolegroup {rolegroup}"))]
+    RoleGroupValidation {
+        rolegroup: RoleGroupRef<KafkaCluster>,
+        source: ValidationError,
+    },
 }
 
 #[derive(Clone, CustomResource, Debug, Deserialize, JsonSchema, Serialize)]
@@ -114,7 +125,7 @@ pub enum Error {
 #[serde(rename_all = "camelCase")]
 pub struct KafkaClusterSpec {
     pub version: Option<String>,
-    pub brokers: Option<Role<KafkaConfig>>,
+    pub brokers: Option<Role<KafkaConfigFragment>>,
     pub zookeeper_config_map_name: String,
     pub opa: Option<OpaConfig>,
     pub log4j: Option<String>,
@@ -198,6 +209,19 @@ impl KafkaCluster {
         }
     }
 
+    pub fn rolegroup(
+        &self,
+        rolegroup_ref: &RoleGroupRef<KafkaCluster>,
+    ) -> Option<(&Role<KafkaConfigFragment>, &RoleGroup<KafkaConfigFragment>)> {
+        match rolegroup_ref.role.parse().ok()? {
+            KafkaRole::Broker => {
+                let role = &self.spec.brokers.as_ref()?;
+                let rg = role.role_groups.get(&rolegroup_ref.role_group)?;
+                Some((role, rg))
+            }
+        }
+    }
+
     /// List all pods expected to form the cluster
     ///
     /// We try to predict the pods here rather than looking at the current cluster state in order to
@@ -223,67 +247,23 @@ impl KafkaCluster {
             }))
     }
 
-    /// Build the [`PersistentVolumeClaim`]s and [`ResourceRequirements`] for the given `rolegroup_ref`.
-    /// These can be defined at the role or rolegroup level and as usual, the
-    /// following precedence rules are implemented:
-    /// 1. group pvc
-    /// 2. role pvc
-    /// 3. a default PVC with 1Gi capacity
-    pub fn resources(
-        &self,
-        rolegroup_ref: &RoleGroupRef<KafkaCluster>,
-    ) -> (Vec<PersistentVolumeClaim>, ResourceRequirements) {
-        let mut role_resources = self.role_resources();
-        role_resources.merge(&Self::default_resources());
-        let mut resources = self.rolegroup_resources(rolegroup_ref);
-        resources.merge(&role_resources);
-
-        let data_pvc = resources
-            .storage
-            .log_dirs
-            .build_pvc(LOG_DIRS_VOLUME_NAME, Some(vec!["ReadWriteOnce"]));
-        let pod_resources = resources.clone().into();
-
-        (vec![data_pvc], pod_resources)
-    }
-
-    fn rolegroup_resources(
-        &self,
-        rolegroup_ref: &RoleGroupRef<KafkaCluster>,
-    ) -> Resources<Storage, NoRuntimeLimits> {
-        let spec: &KafkaClusterSpec = &self.spec;
-
-        spec.brokers
-            .as_ref()
-            .map(|brokers| &brokers.role_groups)
-            .and_then(|role_groups| role_groups.get(&rolegroup_ref.role_group))
-            .map(|role_group| role_group.config.config.resources.clone())
-            .unwrap_or_default()
-    }
-
-    fn role_resources(&self) -> Resources<Storage, NoRuntimeLimits> {
-        let spec: &KafkaClusterSpec = &self.spec;
-        spec.brokers
-            .as_ref()
-            .map(|brokers| brokers.config.config.resources.clone())
-            .unwrap_or_default()
-    }
-
-    fn default_resources() -> Resources<Storage, NoRuntimeLimits> {
-        Resources {
-            cpu: CpuLimits {
-                min: Some(Quantity("500m".to_owned())),
-                max: Some(Quantity("4".to_owned())),
-            },
-            memory: MemoryLimits {
-                limit: Some(Quantity("2Gi".to_owned())),
-                runtime_limits: NoRuntimeLimits {},
-            },
-            storage: Storage {
-                log_dirs: PvcConfig {
-                    capacity: Some(Quantity("1Gi".to_owned())),
-                    storage_class: None,
-                    selectors: None,
+    pub fn broker_default_config() -> KafkaConfigFragment {
+        KafkaConfigFragment {
+            resources: ResourcesFragment {
+                cpu: CpuLimitsFragment {
+                    min: Some(Quantity("500m".to_owned())),
+                    max: Some(Quantity("4".to_owned())),
+                },
+                memory: MemoryLimitsFragment {
+                    limit: Some(Quantity("2Gi".to_owned())),
+                    runtime_limits: NoRuntimeLimitsFragment {},
+                },
+                storage: StorageFragment {
+                    log_dirs: PvcConfigFragment {
+                        capacity: Some(Quantity("1Gi".to_owned())),
+                        storage_class: None,
+                        selectors: None,
+                    },
                 },
             },
         }
@@ -362,6 +342,7 @@ impl KafkaCluster {
 /// Reference to a single `Pod` that is a component of a [`KafkaCluster`]
 ///
 /// Used for service discovery.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KafkaPodRef {
     pub namespace: String,
     pub role_group_service_name: String,
@@ -395,21 +376,54 @@ pub enum KafkaRole {
     Broker,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Merge, JsonSchema, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Fragment, JsonSchema)]
+#[fragment_attrs(
+    derive(
+        Clone,
+        Debug,
+        Default,
+        Deserialize,
+        JsonSchema,
+        Merge,
+        PartialEq,
+        Serialize
+    ),
+    serde(rename_all = "camelCase")
+)]
 pub struct Storage {
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub log_dirs: PvcConfig,
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Default)]
-#[serde(rename_all = "camelCase")]
+impl Storage {
+    pub fn build_pvcs(&self) -> Vec<PersistentVolumeClaim> {
+        let data_pvc = self
+            .log_dirs
+            .build_pvc(LOG_DIRS_VOLUME_NAME, Some(vec!["ReadWriteOnce"]));
+        vec![data_pvc]
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Fragment, JsonSchema)]
+#[fragment_attrs(
+    derive(
+        Clone,
+        Debug,
+        Default,
+        Deserialize,
+        JsonSchema,
+        Merge,
+        PartialEq,
+        Serialize
+    ),
+    serde(rename_all = "camelCase")
+)]
 pub struct KafkaConfig {
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub resources: Resources<Storage, NoRuntimeLimits>,
 }
 
-impl Configuration for KafkaConfig {
+impl Configuration for KafkaConfigFragment {
     type Configurable = KafkaCluster;
 
     fn compute_env(

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 stackable-kafka-crd = { path = "../crd" }
 stackable-kafka-operator = { path = "../operator" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.3" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.26.0" }
 
 clap = { version = "3.2.22", features = ["derive", "env"] }
 tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread"] }
@@ -20,7 +20,7 @@ tracing = "0.1.36"
 
 [build-dependencies]
 built = { version = "0.5.1", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.3" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.26.0" }
 stackable-kafka-crd = { path = "../crd" }
 
 [[bin]]

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 stackable-kafka-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.3" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.26.0" }
 
 futures = "0.3.24"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/rust/operator/src/discovery.rs
+++ b/rust/operator/src/discovery.rs
@@ -149,7 +149,10 @@ async fn nodeport_hosts(
     let endpoints = client
         .get::<Endpoints>(
             svc.metadata.name.as_deref().context(NoNameSnafu)?,
-            svc.metadata.namespace.as_deref(),
+            svc.metadata
+                .namespace
+                .as_deref()
+                .context(NoNamespaceSnafu)?,
         )
         .await
         .with_context(|_| FindEndpointsSnafu {

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -2,8 +2,8 @@
 
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_kafka_crd::{
-    listener::get_kafka_listener_config, KafkaCluster, KafkaRole, TlsSecretClass, APP_NAME,
-    CLIENT_PORT, CLIENT_PORT_NAME, KAFKA_HEAP_OPTS, LOG_DIRS_VOLUME_NAME, METRICS_PORT,
+    listener::get_kafka_listener_config, KafkaCluster, KafkaConfig, KafkaRole, TlsSecretClass,
+    APP_NAME, CLIENT_PORT, CLIENT_PORT_NAME, KAFKA_HEAP_OPTS, LOG_DIRS_VOLUME_NAME, METRICS_PORT,
     METRICS_PORT_NAME, SECURE_CLIENT_PORT, SECURE_CLIENT_PORT_NAME, SERVER_PROPERTIES_FILE,
     STACKABLE_CONFIG_DIR, STACKABLE_DATA_DIR, STACKABLE_TLS_CLIENT_AUTH_DIR,
     STACKABLE_TLS_CLIENT_DIR, STACKABLE_TLS_INTERNAL_DIR, STACKABLE_TMP_DIR,
@@ -20,13 +20,15 @@ use stackable_operator::{
         opa::OpaApiVersion,
         tls::TlsAuthenticationProvider,
     },
+    config::fragment::ValidationError,
     k8s_openapi::{
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
             core::v1::{
                 ConfigMap, ConfigMapKeySelector, ConfigMapVolumeSource, ContainerPort,
                 EmptyDirVolumeSource, EnvVar, EnvVarSource, ExecAction, ObjectFieldSelector,
-                PodSpec, Probe, Service, ServiceAccount, ServicePort, ServiceSpec, Volume,
+                PodSpec, Probe, ResourceRequirements, Service, ServiceAccount, ServicePort,
+                ServiceSpec, Volume,
             },
             rbac::v1::{RoleBinding, RoleRef, Subject},
         },
@@ -143,6 +145,11 @@ pub enum Error {
     RoleGroupNotFound {
         rolegroup: RoleGroupRef<KafkaCluster>,
     },
+    #[snafu(display("failed to validate configuration of rolegroup {rolegroup}"))]
+    RoleGroupValidation {
+        rolegroup: RoleGroupRef<KafkaCluster>,
+        source: ValidationError,
+    },
     #[snafu(display("invalid ServiceAccount"))]
     InvalidServiceAccount {
         source: utils::NamespaceMismatchError,
@@ -214,6 +221,7 @@ impl ReconcilerError for Error {
             Error::BuildDiscoveryConfig { .. } => None,
             Error::ApplyDiscoveryConfig { .. } => None,
             Error::RoleGroupNotFound { .. } => None,
+            Error::RoleGroupValidation { .. } => None,
             Error::InvalidServiceAccount { .. } => None,
             Error::InvalidOpaConfig { .. } => None,
             Error::InvalidJavaHeapConfig { .. } => None,
@@ -269,12 +277,10 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Arc<Ctx>) -> Result<
         .map(Cow::Borrowed)
         .unwrap_or_default();
 
-    // TODO: switch to AuthenticationClass::resolve if operator-rs is updated
     let client_authentication_class = if let Some(auth_class) = kafka.client_authentication_class()
     {
         Some(
-            client
-                .get::<AuthenticationClass>(auth_class, None) // AuthenticationClass has ClusterScope
+            AuthenticationClass::resolve(client, auth_class)
                 .await
                 .context(AuthenticationClassRetrievalSnafu {
                     authentication_class: ObjectRef::<AuthenticationClass>::new(auth_class),
@@ -320,35 +326,48 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Arc<Ctx>) -> Result<
         .context(ApplyRoleRoleBindingSnafu)?;
 
     for (rolegroup_name, rolegroup_config) in role_broker_config.iter() {
-        let rolegroup = kafka.broker_rolegroup_ref(rolegroup_name);
+        let rolegroup_ref = kafka.broker_rolegroup_ref(rolegroup_name);
+        let (role, rolegroup) =
+            kafka
+                .rolegroup(&rolegroup_ref)
+                .with_context(|| RoleGroupNotFoundSnafu {
+                    rolegroup: rolegroup_ref.clone(),
+                })?;
+        let rolegroup_typed_config = rolegroup
+            .validate_config::<KafkaConfig>(role, &KafkaCluster::broker_default_config())
+            .with_context(|_| RoleGroupValidationSnafu {
+                rolegroup: rolegroup_ref.clone(),
+            })?;
 
-        let rg_service = build_broker_rolegroup_service(&rolegroup, &kafka)?;
-        let rg_configmap = build_broker_rolegroup_config_map(&rolegroup, &kafka, rolegroup_config)?;
+        let rg_service = build_broker_rolegroup_service(&rolegroup_ref, &kafka)?;
+        let rg_configmap =
+            build_broker_rolegroup_config_map(&rolegroup_ref, &kafka, rolegroup_config)?;
         let rg_statefulset = build_broker_rolegroup_statefulset(
-            &rolegroup,
+            &rolegroup_ref,
             &kafka,
             rolegroup_config,
             &broker_role_serviceaccount_ref,
             opa_connect.as_deref(),
             client_authentication_class.as_ref(),
+            &rolegroup_typed_config,
         )?;
         cluster_resources
             .add(client, &rg_service)
             .await
             .with_context(|_| ApplyRoleGroupServiceSnafu {
-                rolegroup: rolegroup.clone(),
+                rolegroup: rolegroup_ref.clone(),
             })?;
         cluster_resources
             .add(client, &rg_configmap)
             .await
             .with_context(|_| ApplyRoleGroupConfigSnafu {
-                rolegroup: rolegroup.clone(),
+                rolegroup: rolegroup_ref.clone(),
             })?;
         cluster_resources
             .add(client, &rg_statefulset)
             .await
             .with_context(|_| ApplyRoleGroupStatefulSetSnafu {
-                rolegroup: rolegroup.clone(),
+                rolegroup: rolegroup_ref.clone(),
             })?;
     }
 
@@ -570,6 +589,7 @@ fn build_broker_rolegroup_statefulset(
     serviceaccount: &ObjectRef<ServiceAccount>,
     opa_connect_string: Option<&str>,
     client_authentication_class: Option<&AuthenticationClass>,
+    rolegroup_typed_config: &KafkaConfig,
 ) -> Result<StatefulSet> {
     let mut cb_kafka =
         ContainerBuilder::new(APP_NAME).context(InvalidContainerNameSnafu { name: APP_NAME })?;
@@ -684,7 +704,9 @@ fn build_broker_rolegroup_statefulset(
         .add_volume_mount("tmp", STACKABLE_TMP_DIR)
         .security_context(SecurityContextBuilder::run_as_root());
 
-    let (pvc, resources) = kafka.resources(rolegroup_ref);
+    let resources = rolegroup_typed_config.resources.clone();
+    let pvcs = resources.storage.build_pvcs();
+    let container_resources: ResourceRequirements = resources.into();
 
     let mut env = broker_config
         .get(&PropertyNameKind::Env)
@@ -698,7 +720,7 @@ fn build_broker_rolegroup_statefulset(
         .collect::<Vec<_>>();
 
     if let Some(heap_limits) = kafka
-        .heap_limits(&resources)
+        .heap_limits(&container_resources)
         .context(InvalidJavaHeapConfigSnafu)?
     {
         env.push(EnvVar {
@@ -795,7 +817,7 @@ fn build_broker_rolegroup_statefulset(
         .add_volume_mount(LOG_DIRS_VOLUME_NAME, STACKABLE_DATA_DIR)
         .add_volume_mount("config", STACKABLE_CONFIG_DIR)
         .add_volume_mount("tmp", STACKABLE_TMP_DIR)
-        .resources(resources);
+        .resources(container_resources);
 
     // Use kcat sidecar for probing container status rather than the official Kafka tools, since they incur a lot of
     // unacceptable perf overhead
@@ -887,14 +909,14 @@ fn build_broker_rolegroup_statefulset(
             },
             service_name: rolegroup_ref.object_name(),
             template: pod_template,
-            volume_claim_templates: Some(pvc),
+            volume_claim_templates: Some(pvcs),
             ..StatefulSetSpec::default()
         }),
         status: None,
     })
 }
 
-pub fn error_policy(_error: &Error, _ctx: Arc<Ctx>) -> Action {
+pub fn error_policy(_obj: Arc<KafkaCluster>, _error: &Error, _ctx: Arc<Ctx>) -> Action {
     Action::requeue(Duration::from_secs(5))
 }
 

--- a/rust/operator/src/pod_svc_controller.rs
+++ b/rust/operator/src/pod_svc_controller.rs
@@ -95,6 +95,6 @@ pub async fn reconcile_pod(pod: Arc<Pod>, ctx: Arc<Ctx>) -> Result<Action> {
     Ok(Action::await_change())
 }
 
-pub fn error_policy(_error: &Error, _ctx: Arc<Ctx>) -> Action {
+pub fn error_policy(_obj: Arc<Pod>, _error: &Error, _ctx: Arc<Ctx>) -> Action {
     Action::requeue(Duration::from_secs(5))
 }

--- a/tests/templates/kuttl/configuration/00-assert.yaml
+++ b/tests/templates/kuttl/configuration/00-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-kafka-zk
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-zk-server-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/configuration/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/configuration/00-install-zk.yaml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-kafka-zk
+timeout: 300
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperCluster
+metadata:
+  name: kafka-zk
+spec:
+  servers:
+    roleGroups:
+      default:
+        replicas: 1
+        config:
+          myidOffset: 10
+  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  stopped: false

--- a/tests/templates/kuttl/configuration/01-assert.yaml
+++ b/tests/templates/kuttl/configuration/01-assert.yaml
@@ -27,11 +27,11 @@ spec:
               memory: 1Gi
         - name: kcat-prober
   volumeClaimTemplates:
-  - metadata:
-      name: log-dirs
-    spec:
-      resources:
-        requests:
-          # value set in the role configuration and overridden in
-          # the rolegroup configuration
-          storage: 2Gi
+    - metadata:
+        name: log-dirs
+      spec:
+        resources:
+          requests:
+            # value set in the role configuration and overridden in
+            # the rolegroup configuration
+            storage: 2Gi

--- a/tests/templates/kuttl/configuration/01-assert.yaml
+++ b/tests/templates/kuttl/configuration/01-assert.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-kafka-zk
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: simple-kafka-broker-default
+spec:
+  template:
+    spec:
+      containers:
+        - name: kafka
+          resources:
+            limits:
+              # value set in the role configuration
+              cpu: '1'
+              # value set in the rolegroup configuration
+              memory: 1Gi
+            requests:
+              # default value set by the operator
+              cpu: 500m
+              # value set in the rolegroup configuration
+              memory: 1Gi
+        - name: kcat-prober
+  volumeClaimTemplates:
+  - metadata:
+      name: log-dirs
+    spec:
+      resources:
+        requests:
+          # value set in the role configuration and overridden in
+          # the rolegroup configuration
+          storage: 2Gi

--- a/tests/templates/kuttl/configuration/01-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/configuration/01-install-kafka.yaml.j2
@@ -1,0 +1,52 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-kafka
+timeout: 300
+---
+apiVersion: kafka.stackable.tech/v1alpha1
+kind: KafkaCluster
+metadata:
+  name: simple-kafka
+spec:
+  version: {{ test_scenario['values']['kafka-latest'] }}
+  zookeeperConfigMapName: kafka-zk
+  brokers:
+    config:
+      resources:
+        cpu:
+          # Inherit the default value '500m' set by the operator
+          # min: '500m'
+
+          # Override the default value '4' set by the operator
+          max: '1'
+
+        # memory:
+          # Inherit the default value '2Gi' set by the operator
+          # limit: '2Gi'
+
+        storage:
+          logDirs:
+            # Override the default value '1Gi' set by the operator
+            capacity: '3Gi'
+    roleGroups:
+      default:
+        config:
+          resources:
+            # cpu:
+              # Inherit the default value '500m' set by the operator
+              # min: '500m'
+
+              # Inherit the value '1' set in the role configuration
+              # max: '1'
+
+            memory:
+              # Override the default value '2Gi' set by the operator
+              limit: '1Gi'
+
+            storage:
+              logDirs:
+                # Override the value '3Gi' set in the role configuration
+                capacity: '2Gi'
+        replicas: 1

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -6,6 +6,9 @@ dimensions:
       - 3.1.0-stackable0
       - 3.2.0-stackable0.1.0
       - 3.3.1-stackable0.1.0
+  - name: kafka-latest
+    values:
+      - 3.3.1-stackable0.1.0
   - name: zookeeper
     values:
       - 3.6.3-stackable0.7.1
@@ -40,6 +43,10 @@ tests:
       - kafka
       - zookeeper
       - use-client-tls
+  - name: configuration
+    dimensions:
+      - kafka-latest
+      - zookeeper-latest
   - name: upgrade
     dimensions:
       - zookeeper


### PR DESCRIPTION
# Description

- Role and rolegroup configurations are merged correctly.
- operator-rs: 0.25.3 -> 0.26.0.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Integration tests

[![Build Status](https://ci.stackable.tech/buildStatus/icon?job=kafka-operator-it-custom&build=20)](https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/kafka-operator-it-custom/20/)

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
