### PR TITLE
Remove usage of the tools image

### DIFF
--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -668,7 +668,7 @@ fn build_broker_rolegroup_statefulset(
         .context(InvalidContainerNameSnafu {
             name: "get-svc".to_string(),
         })?
-        .image("docker.stackable.tech/stackable/tools:0.2.0-stackable0.3.0")
+        .image_from_product_image(resolved_product_image)
         .command(vec!["bash".to_string()])
         .args(vec![
             "-euo".to_string(),
@@ -691,7 +691,7 @@ fn build_broker_rolegroup_statefulset(
         .build();
 
     cb_prepare
-        .image("docker.stackable.tech/stackable/tools:0.2.0-stackable0.3.0")
+        .image_from_product_image(resolved_product_image)
         .command(vec![
             "/bin/bash".to_string(),
             "-euo".to_string(),


### PR DESCRIPTION
# Description

With the implementation of the ADR, we can switch away from using a hard-coded tools image. This is an experiment, which will be expanded to other operators as part of https://github.com/stackabletech/docker-images/issues/241

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
