### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -79,13 +79,21 @@ tests:
       - kafka-latest
 
 suites:
-  - name: latest
+  - name: nightly
+    patch:
+      - dimensions:
+          - name: kafka
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: upgrade_old
+            expr: last
+  - name: smoke-latest
+    select:
+      - smoke
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
-    select:
-      - smoke
   - name: openshift
     patch:
       - dimensions:
@@ -93,3 +101,9 @@ suites:
       - dimensions:
           - name: openshift
             expr: "true"
+          - name: kafka
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: upgrade_old
+            expr: last


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62

```
(stackable) ➜  kafka-operator git:(feat/nightly-suite) beku -s nightly     
INFO:root:Expanding test case id [smoke_kafka-3.4.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_use-client-tls-true]
INFO:root:Expanding test case id [smoke_kafka-3.4.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_use-client-tls-false]
INFO:root:Expanding test case id [configuration_kafka-latest-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [upgrade_zookeeper-3.8.0-stackable0.0.0-dev_upgrade_old-3.3.1-stackable0.0.0-dev_upgrade_new-3.4.0-stackable0.0.0-dev_use-client-tls-true_use-client-auth-tls-true_openshift-false]
INFO:root:Expanding test case id [upgrade_zookeeper-3.8.0-stackable0.0.0-dev_upgrade_old-3.3.1-stackable0.0.0-dev_upgrade_new-3.4.0-stackable0.0.0-dev_use-client-tls-true_use-client-auth-tls-false_openshift-false]
INFO:root:Expanding test case id [upgrade_zookeeper-3.8.0-stackable0.0.0-dev_upgrade_old-3.3.1-stackable0.0.0-dev_upgrade_new-3.4.0-stackable0.0.0-dev_use-client-tls-false_use-client-auth-tls-true_openshift-false]
INFO:root:Expanding test case id [upgrade_zookeeper-3.8.0-stackable0.0.0-dev_upgrade_old-3.3.1-stackable0.0.0-dev_upgrade_new-3.4.0-stackable0.0.0-dev_use-client-tls-false_use-client-auth-tls-false_openshift-false]
INFO:root:Expanding test case id [tls_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_use-client-tls-true_use-client-auth-tls-true]
INFO:root:Expanding test case id [tls_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_use-client-tls-true_use-client-auth-tls-false]
INFO:root:Expanding test case id [tls_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_use-client-tls-false_use-client-auth-tls-true]
INFO:root:Expanding test case id [tls_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_use-client-tls-false_use-client-auth-tls-false]
INFO:root:Expanding test case id [delete-rolegroup_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_kafka-latest-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
```
```
(stackable) ➜  kafka-operator git:(feat/nightly-suite) beku -s smoke-latest                                                                                    
INFO:root:Expanding test case id [smoke_kafka-3.4.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_use-client-tls-false]
```
```
(stackable) ➜  kafka-operator git:(feat/nightly-suite) beku -s openshift   
INFO:root:Expanding test case id [smoke_kafka-3.4.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_use-client-tls-false]
INFO:root:Expanding test case id [configuration_kafka-latest-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [upgrade_zookeeper-3.8.0-stackable0.0.0-dev_upgrade_old-3.3.1-stackable0.0.0-dev_upgrade_new-3.4.0-stackable0.0.0-dev_use-client-tls-false_use-client-auth-tls-false_openshift-true]
INFO:root:Expanding test case id [tls_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_use-client-tls-false_use-client-auth-tls-false]
INFO:root:Expanding test case id [delete-rolegroup_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_kafka-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_kafka-latest-3.4.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
```
