### PR TITLE
Let secret op create pkcs12 stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `vector` `0.26.0` -> `0.31.0` ([#612]).
-- `operator-rs` `0.44.0` -> `0.45.1` ([#611]).
+- `operator-rs` `0.44.0` -> `0.48.0` ([#611], [#621]).
+- Let secret-operator handle certificate conversion ([#621]).
 
 [#611]: https://github.com/stackabletech/kafka-operator/pull/611
 [#612]: https://github.com/stackabletech/kafka-operator/pull/612
 [#613]: https://github.com/stackabletech/kafka-operator/pull/613
 [#616]: https://github.com/stackabletech/kafka-operator/pull/616
+[#621]: https://github.com/stackabletech/kafka-operator/pull/621
 
 ## [23.7.0] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to this project will be documented in this file.
 
 - `vector` `0.26.0` -> `0.31.0` ([#612]).
 - `operator-rs` `0.44.0` -> `0.48.0` ([#611], [#621]).
-- BREAKING: Let secret-operator handle certificate conversion. Doing so we were able to remove the `prepare` init container
-  with the effect, that you can't configure the log level for this container any more.
+- [BREAKING]: Let secret-operator handle certificate conversion. Doing so we were able to remove the `prepare` init container
+  with the effect, that you can't configure the log level for this container anymore.
   You need to remove the field `spec.brokers.config.logging.container.prepare` in case you have specified it ([#621]).
 
 [#611]: https://github.com/stackabletech/kafka-operator/pull/611

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ All notable changes to this project will be documented in this file.
 
 - `vector` `0.26.0` -> `0.31.0` ([#612]).
 - `operator-rs` `0.44.0` -> `0.48.0` ([#611], [#621]).
-- Let secret-operator handle certificate conversion ([#621]).
+- BREAKING: Let secret-operator handle certificate conversion. Doing so we were able to remove the `prepare` init container
+  with the effect, that you can't configure the log level for this container any more.
+  You need to remove the field `spec.brokers.config.logging.container.prepare` in case you have specified it ([#621]).
 
 [#611]: https://github.com/stackabletech/kafka-operator/pull/611
 [#612]: https://github.com/stackabletech/kafka-operator/pull/612

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,68 +469,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
+name = "encoding_rs"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
+ "cfg-if",
 ]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "equivalent"
@@ -551,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -564,21 +519,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -828,21 +768,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-openssl"
-version = "0.9.2"
+name = "hyper-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "parking_lot",
+ "log",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-openssl",
- "tower-layer",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -950,11 +888,11 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "java-properties"
-version = "1.4.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1904d8654a1ef51034d02d5a9411b50bf91bea15b0ab644ae179d1325976263"
+checksum = "37bf6f484471c451f2b51eabd9e66b3fa7274550c5ec4b6c3d6070840945117f"
 dependencies = [
- "encoding",
+ "encoding_rs",
  "lazy_static",
  "regex",
 ]
@@ -1043,18 +981,19 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-openssl",
+ "hyper-rustls",
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
  "pin-project",
+ "rustls",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1154,21 +1093,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -1279,42 +1203,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openssl"
-version = "0.10.56"
+name = "openssl-probe"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
@@ -1505,8 +1397,8 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.4.0"
-source = "git+https://github.com/stackabletech/product-config.git?tag=0.4.0#e1e5938b4f6120f85a088194e86d22433fdba731"
+version = "0.5.0"
+source = "git+https://github.com/stackabletech/product-config.git?tag=0.5.0#439869d9e6a72fb6d912f6e494649a2f74f41d25"
 dependencies = [
  "fancy-regex",
  "java-properties",
@@ -1514,7 +1406,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "thiserror",
  "xml-rs",
 ]
@@ -1618,6 +1510,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rstest"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1582,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1635,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "schemars"
@@ -1717,6 +1676,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1693,29 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1795,18 +1787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -1888,6 +1868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "stackable-kafka-crd"
 version = "0.0.0-dev"
 dependencies = [
@@ -1895,7 +1881,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "snafu",
  "stackable-operator",
  "strum",
@@ -1909,7 +1895,7 @@ dependencies = [
  "futures 0.3.28",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "snafu",
  "stackable-kafka-crd",
  "stackable-operator",
@@ -1933,8 +1919,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.46.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.46.0#c88fbe2c5692b773af23b9680d42df00099cf074"
+version = "0.48.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.48.0#ad0aed7c4df39dd6b2c4c81a8f6ca184025550cf"
 dependencies = [
  "chrono",
  "clap",
@@ -1954,7 +1940,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "snafu",
  "stackable-operator-derive",
  "strum",
@@ -1967,8 +1953,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.46.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.46.0#c88fbe2c5692b773af23b9680d42df00099cf074"
+version = "0.48.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.48.0#ad0aed7c4df39dd6b2c4c81a8f6ca184025550cf"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
@@ -2135,14 +2121,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.3"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
+ "rustls",
  "tokio",
 ]
 
@@ -2382,6 +2366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2480,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -2602,15 +2602,6 @@ name = "xml-rs"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.46.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.48.0" }
 strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1.29", features = ["full"] }
 tracing = "0.1"

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -353,7 +353,6 @@ impl Storage {
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum Container {
-    Prepare,
     Vector,
     KcatProber,
     GetService,

--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -255,34 +255,34 @@ impl KafkaTlsSecurity {
         // add tls (server or client authentication volumes) if required
         if let Some(tls_server_secret_class) = self.get_tls_secret_class() {
             // We have to mount tls pem files for kcat (the mount can be used directly)
-            cb_kcat_prober.add_volume_mount(
-                Self::STACKABLE_TLS_CERT_SERVER_DIR_NAME,
-                Self::STACKABLE_TLS_CERT_SERVER_DIR,
-            );
             pod_builder.add_volume(Self::create_tls_volume(
                 Self::STACKABLE_TLS_CERT_SERVER_DIR_NAME,
                 tls_server_secret_class,
             ));
-            // Mounted keystores fore the kafka container
-            cb_kafka.add_volume_mount(
-                Self::STACKABLE_TLS_KEYSTORE_SERVER_DIR_NAME,
-                Self::STACKABLE_TLS_KEYSTORE_SERVER_DIR,
+            cb_kcat_prober.add_volume_mount(
+                Self::STACKABLE_TLS_CERT_SERVER_DIR_NAME,
+                Self::STACKABLE_TLS_CERT_SERVER_DIR,
             );
+            // Keystores fore the kafka container
             pod_builder.add_volume(Self::create_tls_keystore_volume(
                 Self::STACKABLE_TLS_KEYSTORE_SERVER_DIR_NAME,
                 tls_server_secret_class,
             ));
+            cb_kafka.add_volume_mount(
+                Self::STACKABLE_TLS_KEYSTORE_SERVER_DIR_NAME,
+                Self::STACKABLE_TLS_KEYSTORE_SERVER_DIR,
+            );
         }
 
         if let Some(tls_internal_secret_class) = self.tls_internal_secret_class() {
-            cb_kafka.add_volume_mount(
-                Self::STACKABLE_TLS_KEYSTORE_INTERNAL_DIR_NAME,
-                Self::STACKABLE_TLS_KEYSTORE_INTERNAL_DIR,
-            );
             pod_builder.add_volume(Self::create_tls_keystore_volume(
                 Self::STACKABLE_TLS_KEYSTORE_INTERNAL_DIR_NAME,
                 tls_internal_secret_class,
             ));
+            cb_kafka.add_volume_mount(
+                Self::STACKABLE_TLS_KEYSTORE_INTERNAL_DIR_NAME,
+                Self::STACKABLE_TLS_KEYSTORE_INTERNAL_DIR,
+            );
         }
     }
 

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -1,7 +1,7 @@
 //! Ensures that `Pod`s are configured and running for each [`KafkaCluster`]
 use crate::product_logging::{
     extend_role_group_config_map, resolve_vector_aggregator_address, MAX_KAFKA_LOG_FILES_SIZE,
-    MAX_PREPARE_LOG_FILE_SIZE, STACKABLE_LOG_DIR,
+    STACKABLE_LOG_DIR,
 };
 use crate::{
     discovery::{self, build_discovery_configmaps},
@@ -900,7 +900,7 @@ fn build_broker_rolegroup_statefulset(
         .add_empty_dir_volume(
             "log",
             Some(product_logging::framework::calculate_log_volume_size_limit(
-                &[MAX_KAFKA_LOG_FILES_SIZE, MAX_PREPARE_LOG_FILE_SIZE],
+                &[MAX_KAFKA_LOG_FILES_SIZE],
             )),
         )
         .service_account_name(sa_name)

--- a/rust/operator/src/kafka_controller.rs
+++ b/rust/operator/src/kafka_controller.rs
@@ -673,12 +673,6 @@ fn build_broker_rolegroup_statefulset(
         .rolegroup(rolegroup_ref)
         .context(InternalOperatorSnafu)?;
 
-    let prepare_container_name = Container::Prepare.to_string();
-    let mut cb_prepare =
-        ContainerBuilder::new(&prepare_container_name).context(InvalidContainerNameSnafu {
-            name: prepare_container_name.clone(),
-        })?;
-
     let get_svc_container_name = Container::GetService.to_string();
     let mut cb_get_svc =
         ContainerBuilder::new(&get_svc_container_name).context(InvalidContainerNameSnafu {
@@ -702,7 +696,6 @@ fn build_broker_rolegroup_statefulset(
     // Add TLS related volumes and volume mounts
     kafka_security.add_volume_and_volume_mounts(
         &mut pod_builder,
-        &mut cb_prepare,
         &mut cb_kcat_prober,
         &mut cb_kafka,
     );
@@ -728,35 +721,6 @@ fn build_broker_rolegroup_statefulset(
             ..EnvVar::default()
         }])
         .add_volume_mount("tmp", STACKABLE_TMP_DIR)
-        .resources(merged_config.resources.clone().into());
-
-    let mut prepare_container_args = vec![];
-
-    if let Some(ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    }) = merged_config.logging.containers.get(&Container::Prepare)
-    {
-        prepare_container_args.push(product_logging::framework::capture_shell_output(
-            STACKABLE_LOG_DIR,
-            &prepare_container_name,
-            log_config,
-        ));
-    }
-
-    prepare_container_args.extend(kafka_security.prepare_container_command_args());
-
-    cb_prepare
-        .image_from_product_image(resolved_product_image)
-        .command(vec![
-            "/bin/bash".to_string(),
-            "-euo".to_string(),
-            "pipefail".to_string(),
-            "-c".to_string(),
-        ])
-        .args(vec![prepare_container_args.join(" && ")])
-        .add_volume_mount(LOG_DIRS_VOLUME_NAME, STACKABLE_DATA_DIR)
-        .add_volume_mount("tmp", STACKABLE_TMP_DIR)
-        .add_volume_mount("log", STACKABLE_LOG_DIR)
         .resources(merged_config.resources.clone().into());
 
     let pvcs = merged_config.resources.storage.build_pvcs();
@@ -916,7 +880,6 @@ fn build_broker_rolegroup_statefulset(
             .with_label(pod_svc_controller::LABEL_ENABLE, "true")
         })
         .image_pull_secrets_from_product_image(resolved_product_image)
-        .add_init_container(cb_prepare.build())
         .add_init_container(cb_get_svc.build())
         .add_container(cb_kafka.build())
         .add_container(cb_kcat_prober.build())

--- a/rust/operator/src/product_logging.rs
+++ b/rust/operator/src/product_logging.rs
@@ -43,10 +43,6 @@ pub const MAX_KAFKA_LOG_FILES_SIZE: MemoryQuantity = MemoryQuantity {
     value: 10.0,
     unit: BinaryMultiple::Mebi,
 };
-pub const MAX_PREPARE_LOG_FILE_SIZE: MemoryQuantity = MemoryQuantity {
-    value: 1.0,
-    unit: BinaryMultiple::Mebi,
-};
 
 const VECTOR_AGGREGATOR_CM_ENTRY: &str = "ADDRESS";
 const CONSOLE_CONVERSION_PATTERN: &str = "[%d] %p %m (%c)%n";

--- a/tests/templates/kuttl/logging/kafka-vector-aggregator-values.yaml.j2
+++ b/tests/templates/kuttl/logging/kafka-vector-aggregator-values.yaml.j2
@@ -32,12 +32,6 @@ customConfig:
       condition: >-
         .pod == "test-kafka-broker-automatic-log-config-0" &&
         .container == "vector"
-    filteredAutomaticLogConfigBrokerPrepare:
-      type: filter
-      inputs: [vector]
-      condition: >-
-        .pod == "test-kafka-broker-automatic-log-config-0" &&
-        .container == "prepare"
     filteredCustomLogConfigBrokerKafka:
       type: filter
       inputs: [vector]
@@ -50,12 +44,6 @@ customConfig:
       condition: >-
         .pod == "test-kafka-broker-custom-log-config-0" &&
         .container == "vector"
-    filteredCustomLogConfigBrokerPrepare:
-      type: filter
-      inputs: [vector]
-      condition: >-
-        .pod == "test-kafka-broker-custom-log-config-0" &&
-        .container == "prepare"
     filteredInvalidEvents:
       type: filter
       inputs: [vector]

--- a/tests/templates/kuttl/tls/test_client_auth_tls.sh
+++ b/tests/templates/kuttl/tls/test_client_auth_tls.sh
@@ -18,7 +18,7 @@ TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 BAD_TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 
 # write client config
-echo $'security.protocol=SSL\nssl.keystore.location=/stackable/tls_keystore_server/keystore.p12\nssl.keystore.password=changeit\nssl.truststore.location=/stackable/tls_keystore_server/truststore.p12\nssl.truststore.password=changeit' > /tmp/client.config
+echo $'security.protocol=SSL\nssl.keystore.location=/stackable/tls_keystore_server/keystore.p12\nssl.keystore.password=\nssl.truststore.location=/stackable/tls_keystore_server/truststore.p12\nssl.truststore.password=' > /tmp/client.config
 
 if /stackable/kafka/bin/kafka-topics.sh --create --topic "$TOPIC" --bootstrap-server "$SERVER" --command-config /tmp/client.config
 then

--- a/tests/templates/kuttl/tls/test_client_auth_tls.sh
+++ b/tests/templates/kuttl/tls/test_client_auth_tls.sh
@@ -18,7 +18,7 @@ TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 BAD_TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 
 # write client config
-echo $'security.protocol=SSL\nssl.keystore.location=/stackable/tls_server/keystore.p12\nssl.keystore.password=changeit\nssl.truststore.location=/stackable/tls_server/truststore.p12\nssl.truststore.password=changeit' > /tmp/client.config
+echo $'security.protocol=SSL\nssl.keystore.location=/stackable/tls_keystore_server/keystore.p12\nssl.keystore.password=changeit\nssl.truststore.location=/stackable/tls_keystore_server/truststore.p12\nssl.truststore.password=changeit' > /tmp/client.config
 
 if /stackable/kafka/bin/kafka-topics.sh --create --topic "$TOPIC" --bootstrap-server "$SERVER" --command-config /tmp/client.config
 then

--- a/tests/templates/kuttl/tls/test_client_tls.sh
+++ b/tests/templates/kuttl/tls/test_client_tls.sh
@@ -18,7 +18,7 @@ TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 BAD_TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 
 # write client config
-echo $'security.protocol=SSL\nssl.truststore.location=/stackable/tls_keystore_server/truststore.p12\nssl.truststore.password=changeit' > /tmp/client.config
+echo $'security.protocol=SSL\nssl.truststore.location=/stackable/tls_keystore_server/truststore.p12\nssl.truststore.password=' > /tmp/client.config
 
 if /stackable/kafka/bin/kafka-topics.sh --create --topic "$TOPIC" --bootstrap-server "$SERVER" --command-config /tmp/client.config
 then

--- a/tests/templates/kuttl/tls/test_client_tls.sh
+++ b/tests/templates/kuttl/tls/test_client_tls.sh
@@ -18,7 +18,7 @@ TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 BAD_TOPIC=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo '')
 
 # write client config
-echo $'security.protocol=SSL\nssl.truststore.location=/stackable/tls_server/truststore.p12\nssl.truststore.password=changeit' > /tmp/client.config
+echo $'security.protocol=SSL\nssl.truststore.location=/stackable/tls_keystore_server/truststore.p12\nssl.truststore.password=changeit' > /tmp/client.config
 
 if /stackable/kafka/bin/kafka-topics.sh --create --topic "$TOPIC" --bootstrap-server "$SERVER" --command-config /tmp/client.config
 then


### PR DESCRIPTION
# Description

- removed copying of keystores, now accessed directly vom secret-op moints (nothing is added)
- do not import system trust store anymore
- removed prepare container

fixes https://github.com/stackabletech/kafka-operator/issues/618

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
