### PR TITLE
fix(tests): openshift tweaks

### DIFF
--- a/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
@@ -11,9 +11,11 @@ spec:
   template:
     spec:
       serviceAccountName: read-write-data-sa
+      securityContext:
+        runAsGroup: 0
       containers:
         - name: write-data
-          image: edenhill/kcat:1.7.1
+          image: "docker.stackable.tech/stackable/kafka:{{ test_scenario['values']['upgrade_old'] }}-stackable0.0.0-dev"
           command: [sh, -euo, pipefail, -c]
           args:
             - |
@@ -25,7 +27,7 @@ spec:
               export SSL_OPTIONS=""
 {% endif %}
               echo "message written before upgrade" > /tmp/message
-              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P /tmp/message
+              /stackable/kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P /tmp/message
           env:
             - name: KAFKA
               valueFrom:

--- a/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
@@ -15,7 +15,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: write-data
-          image: docker.stackable.tech/stackable/kcat:1.7.0-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/kafka-testing-tools:1.0.0-stackable0.0.0-dev
           command: [sh, -euo, pipefail, -c]
           args:
             - |

--- a/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
@@ -11,8 +11,10 @@ spec:
   template:
     spec:
       serviceAccountName: read-write-data-sa
+{% if test_scenario['values']['openshift'] == "true" %}
       securityContext:
-        runAsGroup: 0
+        runAsUser: 0
+{% endif %}
       containers:
         - name: write-data
           image: docker.stackable.tech/stackable/kafka-testing-tools:1.0.0-stackable0.0.0-dev

--- a/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
@@ -15,7 +15,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: write-data
-          image: "docker.stackable.tech/stackable/kafka:{{ test_scenario['values']['upgrade_old'] }}-stackable0.0.0-dev"
+          image: docker.stackable.tech/stackable/kcat:1.7.0-stackable0.0.0-dev
           command: [sh, -euo, pipefail, -c]
           args:
             - |

--- a/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/03-write-data.yaml.j2
@@ -24,8 +24,8 @@ spec:
 {% else %}
               export SSL_OPTIONS=""
 {% endif %}
-              echo "message written before upgrade" > message
-              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P message
+              echo "message written before upgrade" > /tmp/message
+              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P /tmp/message
           env:
             - name: KAFKA
               valueFrom:

--- a/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
@@ -15,7 +15,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: read-data
-          image: docker.stackable.tech/stackable/kcat:1.7.0-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/kafka-testing-tools:1.0.0-stackable0.0.0-dev
           command: [sh, -euo, pipefail, -c]
           args:
             - |

--- a/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
@@ -11,9 +11,11 @@ spec:
   template:
     spec:
       serviceAccountName: read-write-data-sa
+      securityContext:
+        runAsGroup: 0
       containers:
         - name: read-data
-          image: edenhill/kcat:1.7.1
+          image: "docker.stackable.tech/stackable/kafka:{{ test_scenario['values']['upgrade_new'] }}-stackable0.0.0-dev"
           command: [sh, -euo, pipefail, -c]
           args:
             - |
@@ -25,13 +27,13 @@ spec:
               export SSL_OPTIONS=""
 {% endif %}
               echo "message written after upgrade" > /tmp/message
-              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P /tmp/message
+              /stackable/kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P /tmp/message
 
               echo "message written before upgrade" > /tmp/expected-messages
               echo >> /tmp/expected-messages
               cat /tmp/message >> /tmp/expected-messages
               echo >> /tmp/expected-messages
-              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -C -e > /tmp/read-messages
+              /stackable/kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -C -e > /tmp/read-messages
               diff /tmp/read-messages /tmp/expected-messages
               cmp /tmp/read-messages /tmp/expected-messages
           env:

--- a/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
@@ -11,8 +11,10 @@ spec:
   template:
     spec:
       serviceAccountName: read-write-data-sa
+{% if test_scenario['values']['openshift'] == "true" %}
       securityContext:
-        runAsGroup: 0
+        runAsUser: 0
+{% endif %}
       containers:
         - name: read-data
           image: docker.stackable.tech/stackable/kafka-testing-tools:1.0.0-stackable0.0.0-dev

--- a/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
@@ -24,16 +24,16 @@ spec:
 {% else %}
               export SSL_OPTIONS=""
 {% endif %}
-              echo "message written after upgrade" > message
-              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P message
+              echo "message written after upgrade" > /tmp/message
+              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -P /tmp/message
 
-              echo "message written before upgrade" > expected-messages
-              echo >> expected-messages
-              cat message >> expected-messages
-              echo >> expected-messages
-              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -C -e > read-messages
-              diff read-messages expected-messages
-              cmp read-messages expected-messages
+              echo "message written before upgrade" > /tmp/expected-messages
+              echo >> /tmp/expected-messages
+              cat /tmp/message >> /tmp/expected-messages
+              echo >> /tmp/expected-messages
+              kcat -b $KAFKA $SSL_OPTIONS -t upgrade-test-data -C -e > /tmp/read-messages
+              diff /tmp/read-messages /tmp/expected-messages
+              cmp /tmp/read-messages /tmp/expected-messages
           env:
             - name: KAFKA
               valueFrom:

--- a/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-read-data.yaml.j2
@@ -15,7 +15,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: read-data
-          image: "docker.stackable.tech/stackable/kafka:{{ test_scenario['values']['upgrade_new'] }}-stackable0.0.0-dev"
+          image: docker.stackable.tech/stackable/kcat:1.7.0-stackable0.0.0-dev
           command: [sh, -euo, pipefail, -c]
           args:
             - |

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -102,3 +102,7 @@ suites:
             expr: last
           - name: upgrade_old
             expr: last
+          - name: use-client-tls
+            expr: "true"
+          - name: use-client-auth-tls
+            expr: "true"


### PR DESCRIPTION
# Description

After switching to stand-alone `kcat`, the upgrade test finally succeeded on OpenShift 4.15

```
--- PASS: kuttl (104.91s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.8.3_upgrade_old-3.5.2_upgrade_new-3.6.1_use-client-tls-true_use-client-auth-tls-true_openshift-true (104.67s)
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
