### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/configuration/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/configuration/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/delete-rolegroup/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/delete-rolegroup/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/tls/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/tls/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/upgrade/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/upgrade/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -42,10 +42,12 @@ tests:
       - kafka
       - zookeeper
       - use-client-tls
+      - openshift
   - name: configuration
     dimensions:
       - kafka-latest
       - zookeeper-latest
+      - openshift
   - name: upgrade
     dimensions:
       - zookeeper
@@ -60,18 +62,22 @@ tests:
       - zookeeper-latest
       - use-client-tls
       - use-client-auth-tls
+      - openshift
   - name: delete-rolegroup
     dimensions:
       - kafka
       - zookeeper-latest
+      - openshift
   - name: logging
     dimensions:
       - kafka
       - zookeeper-latest
+      - openshift
   - name: cluster-operation
     dimensions:
       - zookeeper-latest
       - kafka-latest
+      - openshift
 
 suites:
   - name: nightly


### PR DESCRIPTION
# Description


Part of stackabletech/issues#566.

OKD:

```
--- PASS: kuttl (437.58s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_kafka-latest-3.6.1_zookeeper-latest-3.9.1_openshift-true (138.06s)
        --- PASS: kuttl/harness/logging_kafka-3.6.1_zookeeper-latest-3.9.1_openshift-true (151.34s)
        --- PASS: kuttl/harness/delete-rolegroup_kafka-3.6.1_zookeeper-latest-3.9.1_openshift-true (63.12s)
        --- PASS: kuttl/harness/smoke_kafka-3.6.1_zookeeper-3.8.3_use-client-tls-true_openshift-true (81.00s)
        --- PASS: kuttl/harness/tls_kafka-3.6.1_zookeeper-latest-3.9.1_use-client-tls-true_use-client-auth-tls-true_openshift-true (167.13s)
        --- PASS: kuttl/harness/configuration_kafka-latest-3.6.1_zookeeper-latest-3.9.1_openshift-true (29.77s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.8.3_upgrade_old-3.5.2_upgrade_new-3.6.1_use-client-tls-true_use-client-auth-tls-true_openshift-true (123.97s)
```

Azure:

```
--- PASS: kuttl (1888.35s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/tls_kafka-3.6.1_zookeeper-latest-3.9.1_use-client-tls-true_use-client-auth-tls-false_openshift-false (229.97s)
        --- PASS: kuttl/harness/logging_kafka-3.6.1_zookeeper-latest-3.9.1_openshift-false (154.92s)
        --- PASS: kuttl/harness/tls_kafka-3.6.1_zookeeper-latest-3.9.1_use-client-tls-false_use-client-auth-tls-true_openshift-false (195.46s)
        --- PASS: kuttl/harness/tls_kafka-3.6.1_zookeeper-latest-3.9.1_use-client-tls-false_use-client-auth-tls-false_openshift-false (98.26s)
        --- PASS: kuttl/harness/smoke_kafka-3.6.1_zookeeper-3.8.3_use-client-tls-true_openshift-false (135.69s)
        --- PASS: kuttl/harness/smoke_kafka-3.6.1_zookeeper-3.8.3_use-client-tls-false_openshift-false (115.28s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.8.3_upgrade_old-3.5.2_upgrade_new-3.6.1_use-client-tls-true_use-client-auth-tls-true_openshift-false (115.54s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.8.3_upgrade_old-3.5.2_upgrade_new-3.6.1_use-client-tls-true_use-client-auth-tls-false_openshift-false (105.95s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.8.3_upgrade_old-3.5.2_upgrade_new-3.6.1_use-client-tls-false_use-client-auth-tls-true_openshift-false (142.91s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.8.3_upgrade_old-3.5.2_upgrade_new-3.6.1_use-client-tls-false_use-client-auth-tls-false_openshift-false (133.26s)
        --- PASS: kuttl/harness/delete-rolegroup_kafka-3.6.1_zookeeper-latest-3.9.1_openshift-false (64.49s)
        --- PASS: kuttl/harness/cluster-operation_kafka-latest-3.6.1_zookeeper-latest-3.9.1_openshift-false (123.04s)
        --- PASS: kuttl/harness/tls_kafka-3.6.1_zookeeper-latest-3.9.1_use-client-tls-true_use-client-auth-tls-true_openshift-false (192.30s)
        --- PASS: kuttl/harness/configuration_kafka-latest-3.6.1_zookeeper-latest-3.9.1_openshift-false (79.13s)
```



## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
