### PR TITLE
docs: fix kcat command in the getting started guide

### DIFF
--- a/docs/modules/kafka/examples/getting_started/getting_started.sh
+++ b/docs/modules/kafka/examples/getting_started/getting_started.sh
@@ -98,12 +98,12 @@ echo "some test data" > data
 
 echo "Writing test data"
 # tag::kcat-write-data[]
-kafkacat -b localhost:9092 -t test-data-topic -P data
+kcat -b localhost:9092 -t test-data-topic -P data
 # end::kcat-write-data[]
 
 echo "Reading test data"
 # tag::kcat-read-data[]
-kafkacat -b localhost:9092 -t test-data-topic -C -e > read-data.out
+kcat -b localhost:9092 -t test-data-topic -C -e > read-data.out
 # end::kcat-read-data[]
 
 echo "Check contents"


### PR DESCRIPTION
# Description

This is a leftover from the 24.3 release.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
