### PR TITLE
Use kcat in PATH for readiness probe

### DIFF
--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -208,7 +208,7 @@ impl KafkaTlsSecurity {
 
     /// Returns the commands for the kcat readiness probe.
     pub fn kcat_prober_container_commands(&self) -> Vec<String> {
-        let mut args = vec!["/stackable/kcat".to_string()];
+        let mut args = vec!["kcat".to_string()];
         let port = self.client_port();
 
         if self.tls_client_authentication_class().is_some() {


### PR DESCRIPTION
# Description

Use kcat in PATH in kcat readiness probe and instead of the hard-coded location `/stackable/kcat`.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
