### PR TITLE
docs(getting-started): update stackablectl op install output, and make it consistent with other operator docs

### DIFF
--- a/docs/modules/kafka/examples/getting_started/install-operator-output.txt
+++ b/docs/modules/kafka/examples/getting_started/install-operator-output.txt
@@ -1,7 +1,0 @@
-# tag::stackablectl-install-operators-output[]
-Installing commons=0.0.0-dev operator
-Installing secret=0.0.0-dev operator
-Installing listener=0.0.0-dev operator
-Installing zookeeper=0.0.0-dev operator
-Installing kafka=0.0.0-dev operator
-# end::stackablectl-install-operators-output[]

--- a/docs/modules/kafka/examples/getting_started/install-operator-output.txt.j2
+++ b/docs/modules/kafka/examples/getting_started/install-operator-output.txt.j2
@@ -1,7 +1,0 @@
-# tag::stackablectl-install-operators-output[]
-Installing commons={{ versions.commons }} operator
-Installing secret={{ versions.secret }} operator
-Installing listener={{ versions.listener }} operator
-Installing zookeeper={{ versions.zookeeper }} operator
-Installing kafka={{ versions.kafka }} operator
-# end::stackablectl-install-operators-output[]

--- a/docs/modules/kafka/examples/getting_started/install_output.txt
+++ b/docs/modules/kafka/examples/getting_started/install_output.txt
@@ -1,0 +1,5 @@
+Installed commons=0.0.0-dev operator
+Installed secret=0.0.0-dev operator
+Installed listener=0.0.0-dev operator
+Installed zookeeper=0.0.0-dev operator
+Installed kafka=0.0.0-dev operator

--- a/docs/modules/kafka/examples/getting_started/install_output.txt.j2
+++ b/docs/modules/kafka/examples/getting_started/install_output.txt.j2
@@ -1,0 +1,5 @@
+Installed commons={{ versions.commons }} operator
+Installed secret={{ versions.secret }} operator
+Installed listener={{ versions.listener }} operator
+Installed zookeeper={{ versions.zookeeper }} operator
+Installed kafka={{ versions.kafka }} operator

--- a/docs/modules/kafka/pages/getting_started/installation.adoc
+++ b/docs/modules/kafka/pages/getting_started/installation.adoc
@@ -26,9 +26,7 @@ include::example$getting_started/getting_started.sh[tag=stackablectl-install-ope
 The tool will show
 
 [source]
-----
-include::example$getting_started/install-operator-output.txt[tag=stackablectl-install-operators-output]
-----
+include::example$getting_started/install_output.txt[]
 
 TIP: Consult the xref:management:stackablectl:quickstart.adoc[] to learn more about how to use `stackablectl`.
 


### PR DESCRIPTION
This was leftover from #732 

- Rename `install-operator-output.txt*` to install_output.txt*`
- Replace `Installing` with `Installed`