### PR TITLE
fix: Include the bootstrap Kafka service in certificate SANs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Include the global Kafka service (so not the rolegroup-specific) DNS record as SAN entries in the generated
+  certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global service ([#XXX]).
+
 ## [24.7.0] - 2024-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Include the global Kafka service (so not the rolegroup-specific) DNS record as SAN entries in the generated
-  certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global service ([#XXX]).
+- Include the global Kafka service (not the rolegroup-specific) DNS record as SAN entry in the generated
+  certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global service ([#741]).
+
+[#741]: https://github.com/stackabletech/kafka-operator/pull/741
 
 ## [24.7.0] - 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Include the global Kafka service (not the rolegroup-specific) DNS record as SAN entry in the generated
+- Include the global Kafka bootstrap service (not the rolegroup-specific) DNS record as SAN entry in the generated
   certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global service ([#741]).
 
 [#741]: https://github.com/stackabletech/kafka-operator/pull/741

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Include the global Kafka bootstrap service (not the rolegroup-specific) DNS record as SAN entry in the generated
-  certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global service ([#741]).
+  certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global bootstrap
+  service ([#741]).
 
 [#741]: https://github.com/stackabletech/kafka-operator/pull/741
 

--- a/deploy/helm/kafka-operator/crds/crds.yaml
+++ b/deploy/helm/kafka-operator/crds/crds.yaml
@@ -7296,7 +7296,9 @@ spec:
 
                               ## TLS provider
 
-                              Only affects client connections. This setting controls: - If clients need to authenticate themselves against the broker via TLS - Which ca.crt to use when validating the provided client certs This will override the server TLS settings (if set) in `spec.clusterConfig.tls.serverSecretClass`.
+                              Only affects client connections. This setting controls: - If clients need to authenticate themselves against the broker via TLS - Which ca.crt to use when validating the provided client certs
+
+                              This will override the server TLS settings (if set) in `spec.clusterConfig.tls.serverSecretClass`.
                             type: string
                         required:
                           - authenticationClass
@@ -7331,11 +7333,17 @@ spec:
                       properties:
                         internalSecretClass:
                           default: tls
-                          description: 'The [SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass.html) to use for internal broker communication. Use mutual verification between brokers (mandatory). This setting controls: - Which cert the brokers should use to authenticate themselves against other brokers - Which ca.crt to use when validating the other brokers Defaults to `tls`'
+                          description: |-
+                            The [SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass.html) to use for internal broker communication. Use mutual verification between brokers (mandatory). This setting controls: - Which cert the brokers should use to authenticate themselves against other brokers - Which ca.crt to use when validating the other brokers
+
+                            Defaults to `tls`
                           type: string
                         serverSecretClass:
                           default: tls
-                          description: 'The [SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass.html) to use for client connections. This setting controls: - If TLS encryption is used at all - Which cert the servers should use to authenticate themselves against the client Defaults to `tls`.'
+                          description: |-
+                            The [SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass.html) to use for client connections. This setting controls: - If TLS encryption is used at all - Which cert the servers should use to authenticate themselves against the client
+
+                            Defaults to `tls`.
                           nullable: true
                           type: string
                       type: object

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -40,6 +40,7 @@ pub struct KafkaAuthentication {
     /// Only affects client connections. This setting controls:
     /// - If clients need to authenticate themselves against the broker via TLS
     /// - Which ca.crt to use when validating the provided client certs
+    ///
     /// This will override the server TLS settings (if set) in `spec.clusterConfig.tls.serverSecretClass`.
     pub authentication_class: String,
 }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -162,9 +162,10 @@ pub struct KafkaClusterConfig {
 }
 
 impl KafkaCluster {
-    /// The name of the role-level load-balanced Kubernetes `Service`
-    pub fn broker_role_service_name(&self) -> Option<String> {
-        self.metadata.name.clone()
+    /// The name of the load-balanced Kubernetes Service providing the bootstrap address. Kafka clients will use this
+    /// to get a list of broker addresses and will use those to transmit data to the correct broker.
+    pub fn bootstrap_service_name(&self) -> String {
+        self.name_any()
     }
 
     /// Metadata about a broker rolegroup

--- a/rust/crd/src/listener.rs
+++ b/rust/crd/src/listener.rs
@@ -228,6 +228,7 @@ mod tests {
         "#;
         let kafka: KafkaCluster = serde_yaml::from_str(kafka_cluster).expect("illegal test input");
         let kafka_security = KafkaTlsSecurity::new(
+            &kafka,
             ResolvedAuthenticationClasses::new(vec![AuthenticationClass {
                 metadata: ObjectMetaBuilder::new().name("auth-class").build(),
                 spec: AuthenticationClassSpec {
@@ -294,6 +295,7 @@ mod tests {
         "#;
         let kafka: KafkaCluster = serde_yaml::from_str(input).expect("illegal test input");
         let kafka_security = KafkaTlsSecurity::new(
+            &kafka,
             ResolvedAuthenticationClasses::new(vec![]),
             "tls".to_string(),
             Some("tls".to_string()),
@@ -355,6 +357,7 @@ mod tests {
         "#;
         let kafka: KafkaCluster = serde_yaml::from_str(input).expect("illegal test input");
         let kafka_security = KafkaTlsSecurity::new(
+            &kafka,
             ResolvedAuthenticationClasses::new(vec![]),
             "".to_string(),
             None,

--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -17,7 +17,6 @@ use stackable_operator::{
     client::Client,
     commons::authentication::{AuthenticationClass, AuthenticationClassProvider},
     k8s_openapi::api::core::v1::Volume,
-    kube::ResourceExt,
     product_logging::framework::{
         create_vector_shutdown_file_command, remove_vector_shutdown_file_command,
     },
@@ -280,7 +279,7 @@ impl<'a> KafkaTlsSecurity<'a> {
         if let Some(tls_server_secret_class) = self.get_tls_secret_class() {
             // We have to mount tls pem files for kcat (the mount can be used directly)
             pod_builder.add_volume(Self::create_tls_volume(
-                &self.kafka.name_any(),
+                &self.kafka.bootstrap_service_name(),
                 Self::STACKABLE_TLS_CERT_SERVER_DIR_NAME,
                 tls_server_secret_class,
             )?);
@@ -290,7 +289,7 @@ impl<'a> KafkaTlsSecurity<'a> {
             );
             // Keystores fore the kafka container
             pod_builder.add_volume(Self::create_tls_keystore_volume(
-                &self.kafka.name_any(),
+                &self.kafka.bootstrap_service_name(),
                 Self::STACKABLE_TLS_KEYSTORE_SERVER_DIR_NAME,
                 tls_server_secret_class,
             )?);
@@ -302,7 +301,7 @@ impl<'a> KafkaTlsSecurity<'a> {
 
         if let Some(tls_internal_secret_class) = self.tls_internal_secret_class() {
             pod_builder.add_volume(Self::create_tls_keystore_volume(
-                &self.kafka.name_any(),
+                &self.kafka.bootstrap_service_name(),
                 Self::STACKABLE_TLS_KEYSTORE_INTERNAL_DIR_NAME,
                 tls_internal_secret_class,
             )?);

--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -154,6 +154,7 @@ impl<'a> KafkaTlsSecurity<'a> {
     /// Check if TLS encryption is enabled. This could be due to:
     /// - A provided server `SecretClass`
     /// - A provided client `AuthenticationClass`
+    ///
     /// This affects init container commands, Kafka configuration, volume mounts and
     /// the Kafka client port
     pub fn tls_enabled(&self) -> bool {

--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -437,7 +437,7 @@ impl<'a> KafkaTlsSecurity<'a> {
 
     /// Creates ephemeral volumes to mount the `SecretClass` into the Pods
     fn create_tls_volume(
-        kafka_name: &str,
+        kafka_bootstrap_service_name: &str,
         volume_name: &str,
         secret_class_name: &str,
     ) -> Result<Volume, Error> {
@@ -446,9 +446,7 @@ impl<'a> KafkaTlsSecurity<'a> {
                 SecretOperatorVolumeSourceBuilder::new(secret_class_name)
                     .with_pod_scope()
                     .with_node_scope()
-                    // We need to add the DNS SAN of the global kafka service and not only the rolegroup services
-                    // created by the StatefulSet.
-                    .with_service_scope(kafka_name)
+                    .with_service_scope(kafka_bootstrap_service_name)
                     .build()
                     .context(SecretVolumeBuildSnafu)?,
             )
@@ -457,7 +455,7 @@ impl<'a> KafkaTlsSecurity<'a> {
 
     /// Creates ephemeral volumes to mount the `SecretClass` into the Pods as keystores
     fn create_tls_keystore_volume(
-        kafka_name: &str,
+        kafka_bootstrap_service_name: &str,
         volume_name: &str,
         secret_class_name: &str,
     ) -> Result<Volume, Error> {
@@ -466,9 +464,7 @@ impl<'a> KafkaTlsSecurity<'a> {
                 SecretOperatorVolumeSourceBuilder::new(secret_class_name)
                     .with_pod_scope()
                     .with_node_scope()
-                    // We need to add the DNS SAN of the global kafka service and not only the rolegroup services
-                    // created by the StatefulSet.
-                    .with_service_scope(kafka_name)
+                    .with_service_scope(kafka_bootstrap_service_name)
                     .with_format(SecretFormat::TlsPkcs12)
                     .build()
                     .context(SecretVolumeBuildSnafu)?,

--- a/rust/crd/src/tls.rs
+++ b/rust/crd/src/tls.rs
@@ -11,6 +11,7 @@ pub struct KafkaTls {
     /// This setting controls:
     /// - Which cert the brokers should use to authenticate themselves against other brokers
     /// - Which ca.crt to use when validating the other brokers
+    ///
     /// Defaults to `tls`
     #[serde(default = "internal_tls_default")]
     pub internal_secret_class: String,
@@ -18,6 +19,7 @@ pub struct KafkaTls {
     /// client connections. This setting controls:
     /// - If TLS encryption is used at all
     /// - Which cert the servers should use to authenticate themselves against the client
+    ///
     /// Defaults to `tls`.
     #[serde(
         default = "server_tls_default",

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -57,7 +57,7 @@ pub async fn build_discovery_configmaps(
     owner: &impl Resource<DynamicType = ()>,
     resolved_product_image: &ResolvedProductImage,
     client: &stackable_operator::client::Client,
-    kafka_security: &KafkaTlsSecurity,
+    kafka_security: &KafkaTlsSecurity<'_>,
     svc: &Service,
 ) -> Result<Vec<ConfigMap>, Error> {
     let name = owner.name_unchecked();

--- a/rust/operator-binary/src/kafka_controller.rs
+++ b/rust/operator-binary/src/kafka_controller.rs
@@ -717,7 +717,7 @@ fn build_broker_rolegroup_service(
     Ok(Service {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(kafka)
-            .name(&rolegroup.object_name())
+            .name(rolegroup.object_name())
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_recommended_labels(build_recommended_labels(
@@ -1049,7 +1049,7 @@ fn build_broker_rolegroup_statefulset(
     Ok(StatefulSet {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(kafka)
-            .name(&rolegroup_ref.object_name())
+            .name(rolegroup_ref.object_name())
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_recommended_labels(build_recommended_labels(

--- a/rust/operator-binary/src/kafka_controller.rs
+++ b/rust/operator-binary/src/kafka_controller.rs
@@ -587,7 +587,7 @@ pub fn build_bootstrap_service(
     Ok(Service {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(kafka)
-            .name(&kafka.bootstrap_service_name())
+            .name(kafka.bootstrap_service_name())
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_recommended_labels(build_recommended_labels(

--- a/rust/operator-binary/src/kafka_controller.rs
+++ b/rust/operator-binary/src/kafka_controller.rs
@@ -106,9 +106,6 @@ pub enum Error {
     #[snafu(display("object defines no broker role"))]
     NoBrokerRole,
 
-    #[snafu(display("failed to calculate global service name"))]
-    GlobalServiceNameNotFound,
-
     #[snafu(display("failed to apply role Service"))]
     ApplyRoleService {
         source: stackable_operator::cluster_resources::Error,
@@ -324,7 +321,6 @@ impl ReconcilerError for Error {
             Error::ObjectHasNoName => None,
             Error::ObjectHasNoNamespace => None,
             Error::NoBrokerRole => None,
-            Error::GlobalServiceNameNotFound => None,
             Error::ApplyRoleService { .. } => None,
             Error::ApplyRoleServiceAccount { .. } => None,
             Error::ApplyRoleRoleBinding { .. } => None,
@@ -443,7 +439,7 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Arc<Ctx>) -> Result<
     };
 
     let broker_role_service =
-        build_broker_role_service(&kafka, &resolved_product_image, &kafka_security)?;
+        build_bootstrap_service(&kafka, &resolved_product_image, &kafka_security)?;
 
     let broker_role_service = cluster_resources
         .add(client, broker_role_service)
@@ -580,21 +576,18 @@ pub async fn reconcile_kafka(kafka: Arc<KafkaCluster>, ctx: Arc<Ctx>) -> Result<
     Ok(Action::await_change())
 }
 
-/// The broker-role service is the primary endpoint that should be used by clients that do not perform internal load balancing,
-/// including targets outside of the cluster.
-pub fn build_broker_role_service(
+/// Kafka clients will use the load-balanced bootstrap service to get a list of broker addresses and will use those to
+/// transmit data to the correct broker.
+pub fn build_bootstrap_service(
     kafka: &KafkaCluster,
     resolved_product_image: &ResolvedProductImage,
     kafka_security: &KafkaTlsSecurity,
 ) -> Result<Service> {
     let role_name = KafkaRole::Broker.to_string();
-    let role_svc_name = kafka
-        .broker_role_service_name()
-        .context(GlobalServiceNameNotFoundSnafu)?;
     Ok(Service {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(kafka)
-            .name(&role_svc_name)
+            .name(&kafka.bootstrap_service_name())
             .ownerreference_from_resource(kafka, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_recommended_labels(build_recommended_labels(


### PR DESCRIPTION
# Description

Reported in https://stackable-workspace.slack.com/archives/C0312UB3LLE/p1722427738668959.

I am using the broker address from the discovery ConfigMap:

```
$ kubectl get -n stackable-products configmaps kafka -o yaml
apiVersion: v1
kind: ConfigMap
data:
  KAFKA: kafka.stackable-products.svc.cluster.local:9093
```
The Spark job fails with the following exception:
`javax.net.ssl.SSLHandshakeException: No subject alternative DNS name matching kafka.stackable-products.svc.cluster.local found.`

The certificates of the Kafka brokers contain the following SANs:
```
            X509v3 Subject Alternative Name: critical
                DNS:kafka-broker-default.stackable-products.svc.cluster.local, DNS:kafka-broker-default-0.kafka-broker-default.stackable-products.svc.cluster.local, DNS:aks-userpool-28268085-
vmss00000p, IP Address:10.224.1.34, IP Address:172.201.136.222
```



## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
