### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637)

### DIFF
--- a/docs/modules/kafka/pages/usage-guide/logging.adoc
+++ b/docs/modules/kafka/pages/usage-guide/logging.adoc
@@ -15,4 +15,4 @@ spec:
 ----
 
 Further information on how to configure logging, can be found in
-xref:home:concepts:logging.adoc[].
+xref:concepts:logging.adoc[].

--- a/docs/modules/kafka/pages/usage-guide/monitoring.adoc
+++ b/docs/modules/kafka/pages/usage-guide/monitoring.adoc
@@ -1,4 +1,4 @@
 = Monitoring
 
 The managed Kafka instances are automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.

--- a/docs/modules/kafka/pages/usage-guide/storage-resources.adoc
+++ b/docs/modules/kafka/pages/usage-guide/storage-resources.adoc
@@ -22,7 +22,7 @@ If nothing is configured in the custom resource for a certain role group, then b
 
 == Resource Requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 A minimal HA setup consisting of 2 Brokers has the following https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requirements]:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637) / 24.3