### PR TITLE
chore: Add 3.8.0, remove 3.4.1, 3.6.1, 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Support version `3.8.0` ([#753]).
+
 ### Changed
 
 - Reduce CRD size from `479KB` to `53KB` by accepting arbitrary YAML input instead of the underlying schema for the following fields ([#750]):
@@ -16,8 +20,13 @@ All notable changes to this project will be documented in this file.
   certificates used by Kafka. This allows you to access Kafka brokers secured using TLS via the global bootstrap
   service ([#741]).
 
+### Removed
+
+- Remove versions `3.4.1`, `3.6.1`, `3.6.2` ([#753]).
+
 [#741]: https://github.com/stackabletech/kafka-operator/pull/741
 [#750]: https://github.com/stackabletech/kafka-operator/pull/750
+[#753]: https://github.com/stackabletech/kafka-operator/pull/753
 
 ## [24.7.0] - 2024-07-24
 

--- a/docs/modules/kafka/partials/supported-versions.adoc
+++ b/docs/modules/kafka/partials/supported-versions.adoc
@@ -2,7 +2,5 @@
 // This is a separate file, since it is used by both the direct Kafka documentation, and the overarching
 // Stackable Platform documentation.
 
+- 3.8.0
 - 3.7.1 (LTS)
-- 3.6.2 (deprecated)
-- 3.6.1 (deprecated)
-- 3.4.1 (deprecated)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -10,7 +10,7 @@ dimensions:
       - 3.8.0
   - name: kafka-latest
     values:
-      - 3.7.1
+      - 3.7.1 # Using LTS version here
   - name: zookeeper
     values:
       - 3.9.2

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -6,10 +6,8 @@
 dimensions:
   - name: kafka
     values:
-      - 3.4.1
-      - 3.6.1
-      - 3.6.2
       - 3.7.1
+      - 3.8.0
   - name: kafka-latest
     values:
       - 3.7.1
@@ -21,11 +19,10 @@ dimensions:
       - 3.9.2
   - name: upgrade_old
     values:
-      - 3.4.1
-      - 3.6.1
+      - 3.7.1
   - name: upgrade_new
     values:
-      - 3.7.1
+      - 3.8.0
   - name: use-client-tls
     values:
       - "true"


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/626

```[tasklist]
### Dependencies
- [ ] https://github.com/stackabletech/docker-images/pull/813
```

> [!IMPORTANT]
> I have left 3.7.1 as LTS as per spreadsheet, and therefore left the `kafka-latest` test dimension and getting_started version as is.
