### PR TITLE
fix(docs): Update getting-started script pre-24.11

### DIFF
--- a/docs/modules/kafka/examples/getting_started/getting_started.sh
+++ b/docs/modules/kafka/examples/getting_started/getting_started.sh
@@ -86,7 +86,7 @@ kubectl rollout status --watch --timeout=5m statefulset/simple-zk-server-default
 
 echo "Install KafkaCluster from kafka.yaml"
 # tag::install-kafka[]
-kubectl apply -f kafka.yaml
+kubectl apply --server-side -f kafka.yaml
 # end::install-kafka[]
 
 sleep 15
@@ -99,7 +99,7 @@ kubectl rollout status --watch --timeout=5m statefulset/simple-kafka-broker-defa
 echo "Starting port-forwarding of port 9092"
 # shellcheck disable=2069 # we want all output to be blackholed
 # tag::port-forwarding[]
-kubectl port-forward svc/simple-kafka 9092 2>&1 >/dev/null &
+kubectl port-forward svc/simple-kafka-broker-default-bootstrap 9092 2>&1 >/dev/null &
 # end::port-forwarding[]
 PORT_FORWARD_PID=$!
 # shellcheck disable=2064 # we want the PID evaluated now, not at the time the trap is
@@ -114,12 +114,12 @@ echo "some test data" > data
 
 echo "Writing test data"
 # tag::kcat-write-data[]
-kafkacat -b localhost:9092 -t test-data-topic -P data
+kcat -b localhost:9092 -t test-data-topic -P data
 # end::kcat-write-data[]
 
 echo "Reading test data"
 # tag::kcat-read-data[]
-kafkacat -b localhost:9092 -t test-data-topic -C -e > read-data.out
+kcat -b localhost:9092 -t test-data-topic -C -e > read-data.out
 # end::kcat-read-data[]
 
 echo "Check contents"

--- a/docs/modules/kafka/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/kafka/examples/getting_started/getting_started.sh.j2
@@ -86,7 +86,7 @@ kubectl rollout status --watch --timeout=5m statefulset/simple-zk-server-default
 
 echo "Install KafkaCluster from kafka.yaml"
 # tag::install-kafka[]
-kubectl apply -f kafka.yaml
+kubectl apply --server-side -f kafka.yaml
 # end::install-kafka[]
 
 sleep 15
@@ -99,7 +99,7 @@ kubectl rollout status --watch --timeout=5m statefulset/simple-kafka-broker-defa
 echo "Starting port-forwarding of port 9092"
 # shellcheck disable=2069 # we want all output to be blackholed
 # tag::port-forwarding[]
-kubectl port-forward svc/simple-kafka 9092 2>&1 >/dev/null &
+kubectl port-forward svc/simple-kafka-broker-default-bootstrap 9092 2>&1 >/dev/null &
 # end::port-forwarding[]
 PORT_FORWARD_PID=$!
 # shellcheck disable=2064 # we want the PID evaluated now, not at the time the trap is
@@ -114,12 +114,12 @@ echo "some test data" > data
 
 echo "Writing test data"
 # tag::kcat-write-data[]
-kafkacat -b localhost:9092 -t test-data-topic -P data
+kcat -b localhost:9092 -t test-data-topic -P data
 # end::kcat-write-data[]
 
 echo "Reading test data"
 # tag::kcat-read-data[]
-kafkacat -b localhost:9092 -t test-data-topic -C -e > read-data.out
+kcat -b localhost:9092 -t test-data-topic -C -e > read-data.out
 # end::kcat-read-data[]
 
 echo "Check contents"

--- a/docs/modules/kafka/examples/getting_started/kafka.yaml
+++ b/docs/modules/kafka/examples/getting_started/kafka.yaml
@@ -1,4 +1,12 @@
 ---
+apiVersion: listeners.stackable.tech/v1alpha1
+kind: ListenerClass
+metadata:
+  name: external-unstable-ip
+spec:
+  serviceType: NodePort
+  preferredAddressType: IP
+---
 apiVersion: kafka.stackable.tech/v1alpha1
 kind: KafkaCluster
 metadata:
@@ -12,8 +20,8 @@ spec:
     zookeeperConfigMapName: simple-kafka-znode
   brokers:
     config:
-      bootstrapListenerClass: external-unstable # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
-      brokerListenerClass: external-unstable # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
+      bootstrapListenerClass: external-unstable-ip # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
+      brokerListenerClass: external-unstable-ip # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
     roleGroups:
       default:
         replicas: 3


### PR DESCRIPTION
# Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of stackabletech/issues#657.
Use server-side to ensure null fields are not overwritten. Port-forward on bootstrap. kcat in place of kafkacat.

N.B. may not need the external-unstable-ip once https://github.com/stackabletech/listener-operator/pull/244 is merged.

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
