### PR TITLE
doc: Use external-unstable again in getting started guide

### DIFF
--- a/docs/modules/kafka/examples/getting_started/kafka.yaml
+++ b/docs/modules/kafka/examples/getting_started/kafka.yaml
@@ -1,12 +1,4 @@
 ---
-apiVersion: listeners.stackable.tech/v1alpha1
-kind: ListenerClass
-metadata:
-  name: external-unstable-ip
-spec:
-  serviceType: NodePort
-  preferredAddressType: IP
----
 apiVersion: kafka.stackable.tech/v1alpha1
 kind: KafkaCluster
 metadata:
@@ -20,8 +12,8 @@ spec:
     zookeeperConfigMapName: simple-kafka-znode
   brokers:
     config:
-      bootstrapListenerClass: external-unstable-ip # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
-      brokerListenerClass: external-unstable-ip # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
+      bootstrapListenerClass: external-unstable # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
+      brokerListenerClass: external-unstable # This exposes your Stacklet outside of Kubernetes. Remove this property if this is not desired
     roleGroups:
       default:
         replicas: 3


### PR DESCRIPTION
As we have merged https://github.com/stackabletech/listener-operator/pull/244 there is no need for a special ListenerClass any more

# Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
