### PR TITLE
chore(getting_started): Replace templating instructions with make

### DIFF
--- a/docs/modules/kafka/examples/getting_started/getting_started.sh
+++ b/docs/modules/kafka/examples/getting_started/getting_started.sh
@@ -2,18 +2,7 @@
 set -euo pipefail
 
 # DO NOT EDIT THE SCRIPT
-# Instead, update the j2 template, and regenerate it for dev:
-# cat <<EOF | jinja2 --format yaml getting_started.sh.j2 -o getting_started.sh
-# helm:
-#   repo_name: stackable-dev
-#   repo_url: https://repo.stackable.tech/repository/helm-dev/
-# versions:
-#   commons: 0.0.0-dev
-#   kafka: 0.0.0-dev
-#   listener: 0.0.0-dev
-#   secret: 0.0.0-dev
-#   zookeeper: 0.0.0-dev
-# EOF
+# Instead, update the j2 template, and regenerate it for dev with `make render-docs`.
 
 # The getting started guide script
 # It uses tagged regions which are included in the documentation

--- a/docs/modules/kafka/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/kafka/examples/getting_started/getting_started.sh.j2
@@ -2,18 +2,7 @@
 set -euo pipefail
 
 # DO NOT EDIT THE SCRIPT
-# Instead, update the j2 template, and regenerate it for dev:
-# cat <<EOF | jinja2 --format yaml getting_started.sh.j2 -o getting_started.sh
-# helm:
-#   repo_name: stackable-dev
-#   repo_url: https://repo.stackable.tech/repository/helm-dev/
-# versions:
-#   commons: 0.0.0-dev
-#   kafka: 0.0.0-dev
-#   listener: 0.0.0-dev
-#   secret: 0.0.0-dev
-#   zookeeper: 0.0.0-dev
-# EOF
+# Instead, update the j2 template, and regenerate it for dev with `make render-docs`.
 
 # The getting started guide script
 # It uses tagged regions which are included in the documentation


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/611.

Depends on https://github.com/stackabletech/kafka-operator/pull/790.