### PR TITLE
test: Revert back to 3.8.0

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -8,7 +8,7 @@ dimensions:
     values:
       - 3.7.1
       - 3.7.2
-      - 3.8.1
+      - 3.8.0
       - 3.9.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.


### PR DESCRIPTION
# Description

We decided not to to with Kafka 3.8.1 for SDP 25.3.0, so this drops back to 3.8.0.
See also: https://github.com/stackabletech/docker-images/pull/1021

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
