### PR TITLE
chore(docs): Update getting-started script pre-25.3.0

### DIFF
--- a/docs/modules/kafka/examples/getting_started/kafka.yaml
+++ b/docs/modules/kafka/examples/getting_started/kafka.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.0
   clusterConfig:
     tls:
       serverSecretClass: null


### PR DESCRIPTION
# Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/697>

This PR bumps the following:

- `kafka` to 3.9.0

```shell
# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm
```
