### PR TITLE
chore: remove -nodeport discovery configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 - test: ZooKeeper 3.9.2 removed ([#853]).
 - Support for Kafka 3.7.1 and 3.8.0 removed ([#860]).
+- Remove the `-nodeport` discovery ConfigMap ([#868]).
 
 [#840]: https://github.com/stackabletech/kafka-operator/pull/840
 [#844]: https://github.com/stackabletech/kafka-operator/pull/844
@@ -48,6 +49,7 @@ All notable changes to this project will be documented in this file.
 [#860]: https://github.com/stackabletech/kafka-operator/pull/860
 [#861]: https://github.com/stackabletech/kafka-operator/pull/861
 [#862]: https://github.com/stackabletech/kafka-operator/pull/862
+[#868]: https://github.com/stackabletech/kafka-operator/pull/868
 
 ## [25.3.0] - 2025-03-21
 

--- a/docs/modules/kafka/pages/reference/discovery.adoc
+++ b/docs/modules/kafka/pages/reference/discovery.adoc
@@ -9,8 +9,6 @@ The Stackable Operator for Apache Kafka publishes a xref:concepts:service_discov
 
 The bundle includes a thrift connection string to access the Kafka broker service. This string may be used by other operators or tools to configure their products with access to Kafka. This is limited to internal cluster access.
 
-NOTE: The operator also creates a deprecated secondary discovery ConfigMap named `\{clusterName\}-nodeport`. In 24.7 and older, this ConfigMap was used to access the Kafka installation from outside the Kubernetes cluster. In 24.11, this was replaced by xref:usage-guide/listenerclass.adoc[Listener-based exposition], and the `-nodeport` ConfigMap was made equivalent to the primary one. This behaviour is deprecated as of 25.3, and will be removed in the next release. Any existing uses of the `-nodeport` ConfigMap should be migrated to the primary. See https://github.com/stackabletech/kafka-operator/issues/765[the deprecation issue] for more details.
-
 == Example
 
 Given the following Kafka cluster:

--- a/rust/operator-binary/src/kafka_controller.rs
+++ b/rust/operator-binary/src/kafka_controller.rs
@@ -84,7 +84,7 @@ use crate::{
         security::KafkaTlsSecurity,
         v1alpha1,
     },
-    discovery::{self, build_discovery_configmaps},
+    discovery::{self, build_discovery_configmap},
     kerberos::{self, add_kerberos_pod_config},
     operations::{
         graceful_shutdown::{add_graceful_shutdown_config, graceful_shutdown_config_properties},
@@ -596,21 +596,19 @@ pub async fn reconcile_kafka(
             .context(FailedToCreatePdbSnafu)?;
     }
 
-    for discovery_cm in build_discovery_configmaps(
+    let discovery_cm = build_discovery_configmap(
         kafka,
         kafka,
         &resolved_product_image,
         &kafka_security,
         &bootstrap_listeners,
     )
-    .await
-    .context(BuildDiscoveryConfigSnafu)?
-    {
-        cluster_resources
-            .add(client, discovery_cm)
-            .await
-            .context(ApplyDiscoveryConfigSnafu)?;
-    }
+    .context(BuildDiscoveryConfigSnafu)?;
+
+    cluster_resources
+        .add(client, discovery_cm)
+        .await
+        .context(ApplyDiscoveryConfigSnafu)?;
 
     let cluster_operation_cond_builder =
         ClusterOperationsConditionBuilder::new(&kafka.spec.cluster_operation);


### PR DESCRIPTION
## Description

Implementation for https://github.com/stackabletech/kafka-operator/issues/765. Removes the deprecated `-nodeport` discovery ConfigMap (https://github.com/stackabletech/kafka-operator/pull/813). Removes the Note about the `-nodeport` discovery CM from the [Discovery page](https://docs.stackable.tech/home/nightly/kafka/reference/discovery/) of Kafka Operator.

### Integrationtests
```
--- PASS: kuttl (828.67s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/configuration_kafka-latest-3.7.2_zookeeper-latest-3.9.3_openshift-false (31.21s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.0_zookeeper-3.9.3_use-client-tls-false_openshift-false (98.06s)
        --- PASS: kuttl/harness/cluster-operation_kafka-latest-3.7.2_zookeeper-latest-3.9.3_openshift-false (80.41s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.0_use-client-tls-true_use-client-auth-tls-true_openshift-false (80.75s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.0_use-client-tls-true_use-client-auth-tls-false_openshift-false (77.88s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.0_use-client-tls-false_use-client-auth-tls-true_openshift-false (76.35s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.0_use-client-tls-false_use-client-auth-tls-false_openshift-false (71.85s)
        --- PASS: kuttl/harness/tls_kafka-3.9.0_zookeeper-latest-3.9.3_use-client-tls-true_use-client-auth-tls-false_openshift-false (127.90s)
        --- PASS: kuttl/harness/tls_kafka-3.9.0_zookeeper-latest-3.9.3_use-client-tls-true_use-client-auth-tls-true_openshift-false (134.67s)
        --- PASS: kuttl/harness/tls_kafka-3.9.0_zookeeper-latest-3.9.3_use-client-tls-false_use-client-auth-tls-false_openshift-false (53.97s)
        --- PASS: kuttl/harness/tls_kafka-3.9.0_zookeeper-latest-3.9.3_use-client-tls-false_use-client-auth-tls-true_openshift-false (129.18s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-stable (77.78s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (77.15s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-stable (87.21s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-cluster-internal (75.09s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (95.02s)
        --- PASS: kuttl/harness/logging_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false (67.65s)
        --- PASS: kuttl/harness/delete-rolegroup_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false (49.97s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-cluster-internal (74.14s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.0_zookeeper-3.9.3_use-client-tls-true_openshift-false (45.35s)
PASS
```
#### Openshift
```
--- PASS: kuttl (382.91s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/delete-rolegroup_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-true (75.04s)
        --- PASS: kuttl/harness/configuration_kafka-latest-3.7.2_zookeeper-latest-3.9.3_openshift-true (34.90s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.0_zookeeper-3.9.3_use-client-tls-true_openshift-true (134.25s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-true_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (80.71s)
        --- PASS: kuttl/harness/cluster-operation_kafka-latest-3.7.2_zookeeper-latest-3.9.3_openshift-true (102.50s)
        --- PASS: kuttl/harness/logging_kafka-3.9.0_zookeeper-latest-3.9.3_openshift-true (78.03s)
        --- PASS: kuttl/harness/tls_kafka-3.9.0_zookeeper-latest-3.9.3_use-client-tls-true_use-client-auth-tls-true_openshift-true (131.33s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.0_use-client-tls-true_use-client-auth-tls-true_openshift-true (104.63s)
PASS
```

## Release Note Snippet
The `-nodeport` discovery ConfigMap has been deprecated in 25.3 and is removed as of this release. Use the primary discovery ConfigMap instead.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [x] Links to generated (nightly) docs added
- [x] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
