### PR TITLE
chore: deprecate 3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Helm: Allow Pod `priorityClassName` to be configured ([#890]).
+- Add experimental support for Kafka KRaft mode ([#889]).
+- Add experimental support for Kafka `4.0.0` ([#889]).
 
+### Changed
+
+- Deprecate support for Kafka `3.7.2` ([#892]).
+
+[#889]: https://github.com/stackabletech/kafka-operator/pull/889
 [#890]: https://github.com/stackabletech/kafka-operator/pull/890
+[#892]: https://github.com/stackabletech/kafka-operator/pull/892
 
 ## [25.7.0] - 2025-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Helm: Allow Pod `priorityClassName` to be configured ([#890]).
 - Add experimental support for Kafka KRaft mode ([#889]).
-- Add experimental support for Kafka `4.0.0` ([#889]).
+- Add experimental support for Kafka `4.1.0` ([#889]).
 
 ### Changed
 

--- a/docs/modules/kafka/pages/usage-guide/security.adoc
+++ b/docs/modules/kafka/pages/usage-guide/security.adoc
@@ -15,7 +15,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     zookeeperConfigMapName: simple-kafka-znode
     tls:
@@ -95,7 +95,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authentication:
       - authenticationClass: kafka-client-tls # <1>
@@ -140,7 +140,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authentication:
       - authenticationClass: kafka-client-kerberos # <1>
@@ -184,7 +184,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authorization:
       opa:
@@ -208,7 +208,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authorization:
       opa:

--- a/docs/modules/kafka/partials/supported-versions.adoc
+++ b/docs/modules/kafka/partials/supported-versions.adoc
@@ -3,5 +3,5 @@
 // Stackable Platform documentation.
 
 * 4.1.0 (experimental)
-* 3.9.1
-* 3.7.2 (LTS)
+* 3.9.1 (LTS)
+* 3.7.2 (deprecated)

--- a/examples/logging/simple-kafka-cluster-opa-log4j.yaml
+++ b/examples/logging/simple-kafka-cluster-opa-log4j.yaml
@@ -50,7 +50,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authorization:
       opa:

--- a/examples/opa/simple-kafka-cluster-opa-allow-all.yaml
+++ b/examples/opa/simple-kafka-cluster-opa-allow-all.yaml
@@ -50,7 +50,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authorization:
       opa:

--- a/examples/tls/simple-kafka-cluster-tls.yaml
+++ b/examples/tls/simple-kafka-cluster-tls.yaml
@@ -60,7 +60,7 @@ metadata:
   name: simple-kafka
 spec:
   image:
-    productVersion: 3.7.2
+    productVersion: 3.9.1
   clusterConfig:
     authentication:
       - authenticationClass: kafka-client-auth-tls

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -114,7 +114,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             zookeeperConfigMapName: xyz
           brokers:
@@ -144,7 +144,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             zookeeperConfigMapName: xyz
           brokers:

--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -44,7 +44,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             zookeeperConfigMapName: xyz
           brokers:

--- a/rust/operator-binary/src/crd/listener.rs
+++ b/rust/operator-binary/src/crd/listener.rs
@@ -375,7 +375,7 @@ mod tests {
           namespace: default
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             authentication:
               - authenticationClass: kafka-client-tls
@@ -563,7 +563,7 @@ mod tests {
           namespace: default
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             authentication:
               - authenticationClass: kafka-kerberos

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -430,7 +430,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             zookeeperConfigMapName: xyz
         "#;
@@ -449,7 +449,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             tls:
               serverSecretClass: simple-kafka-server-tls
@@ -474,7 +474,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             tls:
               serverSecretClass: null
@@ -495,7 +495,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           zookeeperConfigMapName: xyz
           clusterConfig:
             tls:
@@ -520,7 +520,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             zookeeperConfigMapName: xyz
         "#;
@@ -539,7 +539,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             tls:
               internalSecretClass: simple-kafka-internal-tls
@@ -560,7 +560,7 @@ mod tests {
           name: simple-kafka
         spec:
           image:
-            productVersion: 3.7.2
+            productVersion: 3.9.1
           clusterConfig:
             tls:
               serverSecretClass: simple-kafka-server-tls

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -15,13 +15,13 @@ dimensions:
       - 3.9.1
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      # - 3.8.0,oci.stackable.tech/sdp/kafka:3.8.0-stackable0.0.0-dev
+      # - 3.9.1,oci.stackable.tech/sdp/kafka:3.9.1-stackable0.0.0-dev
   - name: kafka-latest
     values:
-      - 3.7.2 # Using LTS version here
+      - 3.9.1 # Using LTS version here
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      # - 3.7.2,oci.stackable.tech/sdp/kafka:3.7.2-stackable0.0.0-dev
+      # - 3.9.1,oci.stackable.tech/sdp/kafka:3.9.1-stackable0.0.0-dev
   - name: zookeeper
     values:
       - 3.9.3


### PR DESCRIPTION
## Description

- deprecated in supported versions
- replaced in unittests
- not using as LTS in tests anymore
- added missing changelog entry for https://github.com/stackabletech/kafka-operator/pull/889

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
