### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/docs/modules/kafka/examples/getting_started/zookeeper.yaml
+++ b/docs/modules/kafka/examples/getting_started/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -25,9 +25,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
   - name: upgrade_old
     values:
       - 3.7.2


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- FAIL: kuttl (4597.53s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-cluster-internal (167.88s)
        --- PASS: kuttl/harness/tls_kafka-3.7.2_zookeeper-latest-3.9.4_use-client-tls-false_use-client-auth-tls-false_openshift-false (274.66s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (119.61s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-false_use-client-auth-tls-false_openshift-false (86.85s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (123.84s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-stable (123.05s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-cluster-internal (152.41s)
        --- PASS: kuttl/harness/kerberos_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (120.11s)
        --- PASS: kuttl/harness/kerberos_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-stable (118.21s)
        --- PASS: kuttl/harness/kerberos_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-cluster-internal (129.56s)
        --- PASS: kuttl/harness/kerberos_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-unstable (121.90s)
        --- PASS: kuttl/harness/kerberos_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-cluster-internal (123.58s)
        --- PASS: kuttl/harness/kerberos_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-stable (246.68s)
        --- PASS: kuttl/harness/smoke-kraft_kafka-kraft-4.1.0_openshift-false (547.69s)
        --- PASS: kuttl/harness/smoke-kraft_kafka-kraft-3.9.1_openshift-false (494.42s)
        --- PASS: kuttl/harness/delete-rolegroup_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false (64.23s)
        --- PASS: kuttl/harness/delete-rolegroup_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false (55.41s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.4_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-true_use-client-auth-tls-true_openshift-false (78.54s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.4_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-true_use-client-auth-tls-false_openshift-false (91.13s)
        --- PASS: kuttl/harness/smoke-kraft_kafka-kraft-3.7.2_openshift-false (299.79s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.4_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-false_use-client-auth-tls-true_openshift-false (91.06s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.4_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-false_use-client-auth-tls-false_openshift-false (92.98s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-true_use-client-auth-tls-true_openshift-false (90.12s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-true_use-client-auth-tls-false_openshift-false (81.92s)
        --- PASS: kuttl/harness/upgrade_zookeeper-3.9.3_upgrade_old-3.7.2_upgrade_new-3.9.1_use-client-tls-false_use-client-auth-tls-true_openshift-false (80.19s)
        --- PASS: kuttl/harness/cluster-operation_kafka-latest-3.9.1_zookeeper-latest-3.9.4_openshift-false (77.93s)
        --- PASS: kuttl/harness/operations-kraft_kafka-kraft-3.9.1_openshift-false (350.06s)
        --- PASS: kuttl/harness/operations-kraft_kafka-kraft-4.1.0_openshift-false (353.03s)
        --- PASS: kuttl/harness/configuration_kafka-latest-3.9.1_openshift-false (12.32s)
        --- PASS: kuttl/harness/operations-kraft_kafka-kraft-3.7.2_openshift-false (297.74s)
        --- PASS: kuttl/harness/smoke_kafka-3.7.2_zookeeper-3.9.4_use-client-tls-true_openshift-false (84.15s)
        --- FAIL: kuttl/harness/tls_kafka-3.9.1_zookeeper-latest-3.9.4_use-client-tls-true_use-client-auth-tls-false_openshift-false (423.55s)
        --- PASS: kuttl/harness/smoke_kafka-3.7.2_zookeeper-3.9.4_use-client-tls-false_openshift-false (85.60s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.1_zookeeper-3.9.3_use-client-tls-false_openshift-false (86.34s)
        --- PASS: kuttl/harness/logging_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false (130.04s)
        --- PASS: kuttl/harness/smoke_kafka-3.7.2_zookeeper-3.9.3_use-client-tls-true_openshift-false (90.46s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.1_zookeeper-3.9.4_use-client-tls-true_openshift-false (91.26s)
        --- PASS: kuttl/harness/smoke_kafka-3.7.2_zookeeper-3.9.3_use-client-tls-false_openshift-false (87.37s)
        --- PASS: kuttl/harness/logging_kafka-3.7.2_zookeeper-latest-3.9.4_openshift-false (373.22s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.1_zookeeper-3.9.4_use-client-tls-false_openshift-false (83.23s)
        --- PASS: kuttl/harness/tls_kafka-3.9.1_zookeeper-latest-3.9.4_use-client-tls-true_use-client-auth-tls-true_openshift-false (330.05s)
        --- PASS: kuttl/harness/smoke_kafka-3.9.1_zookeeper-3.9.3_use-client-tls-true_openshift-false (88.59s)
        --- FAIL: kuttl/harness/tls_kafka-3.7.2_zookeeper-latest-3.9.4_use-client-tls-true_use-client-auth-tls-true_openshift-false (426.77s)
        --- PASS: kuttl/harness/tls_kafka-3.9.1_zookeeper-latest-3.9.4_use-client-tls-false_use-client-auth-tls-true_openshift-false (212.88s)
        --- PASS: kuttl/harness/tls_kafka-3.9.1_zookeeper-latest-3.9.4_use-client-tls-false_use-client-auth-tls-false_openshift-false (299.54s)
        --- PASS: kuttl/harness/tls_kafka-3.7.2_zookeeper-latest-3.9.4_use-client-tls-true_use-client-auth-tls-false_openshift-false (391.37s)
        --- PASS: kuttl/harness/kerberos_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false_krb5-1.21.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_broker-listener-class-cluster-internal_bootstrap-listener-class-external-stable (119.69s)
        --- FAIL: kuttl/harness/tls_kafka-3.7.2_zookeeper-latest-3.9.4_use-client-tls-false_use-client-auth-tls-true_openshift-false (421.67s)
FAIL
```

The failed tests just timed out on namespace deletion

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
