### PR TITLE
Added 'metadataManager: kraft' to the KRaft example in the docs.

### DIFF
--- a/docs/modules/kafka/pages/usage-guide/kraft-controller.adoc
+++ b/docs/modules/kafka/pages/usage-guide/kraft-controller.adoc
@@ -28,6 +28,8 @@ kind: KafkaCluster
 metadata:
   name: kafka
 spec:
+  clusterConfig:
+    metadataManager: kraft
   image:
     productVersion: "3.9.1"
   brokers:


### PR DESCRIPTION
## Description
The current snippet in the docs for standing up a KRaft cluster ends up crashlooping, because Kafka 3.x still defaults to zookeeper and requires setting KRaft explicitly.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Links to generated (nightly) docs added

### Reviewer

- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
