### PR TITLE
fix: Add orderly shutdown steps to all kuttl tests

### DIFF
--- a/tests/templates/kuttl/cluster-operation/20-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/20-install-kafka.yaml.j2
@@ -23,6 +23,7 @@ spec:
     zookeeperConfigMapName: test-zk
   brokers:
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/cluster-operation/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/cluster-operation/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/configuration/10-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/configuration/10-install-kafka.yaml.j2
@@ -23,6 +23,7 @@ spec:
 {% endif %}
   controllers:
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:
@@ -57,6 +58,7 @@ spec:
         replicas: 1
   brokers:
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:

--- a/tests/templates/kuttl/configuration/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/configuration/90-shutdown-kafka.yaml
@@ -1,0 +1,25 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Brokers are scaled via the CRD so the operator performs an orderly shutdown.
+# Once brokers are gone, we delete the KafkaCluster CR to stop the operator
+# reconciling, then force-delete any remaining controller pods. We cannot scale
+# controllers via the CRD because the operator errors with "no Kraft controllers
+# found to build ConfigMap", and scaling the StatefulSet directly is immediately
+# reversed by the operator's reconciliation loop.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=300s
+  - script: |
+      kubectl delete kafkacluster test-kafka -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --timeout=120s 2>/dev/null || true

--- a/tests/templates/kuttl/delete-rolegroup/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/delete-rolegroup/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0},"secondary":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/kerberos/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/kerberos/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/logging/04-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/logging/04-install-kafka.yaml.j2
@@ -52,6 +52,8 @@ spec:
     vectorAggregatorConfigMapName: kafka-vector-aggregator-discovery
     zookeeperConfigMapName: test-kafka-znode
   brokers:
+    config:
+      gracefulShutdownTimeout: 60s
     roleGroups:
       automatic-log-config:
         replicas: 1

--- a/tests/templates/kuttl/logging/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/logging/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"automatic-log-config":{"replicas":0},"custom-log-config":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/opa/30-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/opa/30-install-kafka.yaml.j2
@@ -42,6 +42,7 @@ commands:
           config:
             logging:
               enableVectorAgent: true
+            gracefulShutdownTimeout: 60s
           roleGroups:
             default:
               replicas: 3

--- a/tests/templates/kuttl/opa/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/opa/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/operations-kraft/20-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/operations-kraft/20-install-kafka.yaml.j2
@@ -23,6 +23,7 @@ spec:
 {% endif %}
   controllers:
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -30,6 +31,7 @@ spec:
         replicas: 3
   brokers:
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/operations-kraft/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/operations-kraft/90-shutdown-kafka.yaml
@@ -1,0 +1,25 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Brokers are scaled via the CRD so the operator performs an orderly shutdown.
+# Once brokers are gone, we delete the KafkaCluster CR to stop the operator
+# reconciling, then force-delete any remaining controller pods. We cannot scale
+# controllers via the CRD because the operator errors with "no Kraft controllers
+# found to build ConfigMap", and scaling the StatefulSet directly is immediately
+# reversed by the operator's reconciliation loop.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=300s
+  - script: |
+      kubectl delete kafkacluster test-kafka -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --timeout=120s 2>/dev/null || true

--- a/tests/templates/kuttl/smoke-kraft/30-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/smoke-kraft/30-install-kafka.yaml.j2
@@ -80,6 +80,7 @@ spec:
       COMMON_VAR: role-value # overridden by role group below
       ROLE_VAR: role-value   # only defined here at role level
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: true
       requestedSecretLifetime: 7d
@@ -135,6 +136,7 @@ spec:
       COMMON_VAR: role-value # overridden by role group below
       ROLE_VAR: role-value   # only defined here at role level
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: true
       requestedSecretLifetime: 7d

--- a/tests/templates/kuttl/smoke-kraft/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/smoke-kraft/90-shutdown-kafka.yaml
@@ -1,0 +1,25 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Brokers are scaled via the CRD so the operator performs an orderly shutdown.
+# Once brokers are gone, we delete the KafkaCluster CR to stop the operator
+# reconciling, then force-delete any remaining controller pods. We cannot scale
+# controllers via the CRD because the operator errors with "no Kraft controllers
+# found to build ConfigMap", and scaling the StatefulSet directly is immediately
+# reversed by the operator's reconciliation loop.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0},"automatic-log-config":{"replicas":0},"custom-log-config":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=300s
+  - script: |
+      kubectl delete kafkacluster test-kafka -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --timeout=120s 2>/dev/null || true

--- a/tests/templates/kuttl/smoke/30-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-kafka.yaml.j2
@@ -28,6 +28,8 @@ spec:
 {% endif %}
     zookeeperConfigMapName: test-zk
   brokers:
+    config:
+      gracefulShutdownTimeout: 60s
     configOverrides:
       broker.properties:
         compression.type: uncompressed # overridden by role group below

--- a/tests/templates/kuttl/smoke/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/smoke/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/tls/40-install-kafka.yaml.j2
+++ b/tests/templates/kuttl/tls/40-install-kafka.yaml.j2
@@ -61,6 +61,7 @@ spec:
     zookeeperConfigMapName: test-kafka-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 60s
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/tls/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/tls/90-shutdown-kafka.yaml
@@ -1,0 +1,18 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Without this, ZooKeeper and Kafka are terminated simultaneously during
+# namespace deletion. Kafka's controlled-shutdown retries ZK connections
+# indefinitely, keeping the process alive for the full grace period
+# and blocking namespace deletion well past kuttl's 300s timeout.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka -n $NAMESPACE --timeout=300s

--- a/tests/templates/kuttl/upgrade/90-shutdown-kafka.yaml
+++ b/tests/templates/kuttl/upgrade/90-shutdown-kafka.yaml
@@ -1,0 +1,25 @@
+---
+# Scale Kafka down before kuttl deletes the namespace.
+# Brokers are scaled via the CRD so the operator performs an orderly shutdown.
+# Once brokers are gone, we delete the KafkaCluster CR to stop the operator
+# reconciling, then force-delete any remaining controller pods. We cannot scale
+# controllers via the CRD because the operator errors with "no Kraft controllers
+# found to build ConfigMap", and scaling the StatefulSet directly is immediately
+# reversed by the operator's reconciliation loop.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: |
+      kubectl patch kafkacluster test-kafka -n $NAMESPACE --type merge -p '{"spec":{"brokers":{"roleGroups":{"default":{"replicas":0}}}}}'
+  - script: |
+      if kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=120s 2>/dev/null; then
+        exit 0
+      fi
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=broker -n $NAMESPACE --timeout=300s
+  - script: |
+      kubectl delete kafkacluster test-kafka -n $NAMESPACE --wait=false 2>/dev/null || true
+  - script: |
+      kubectl delete pods -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --grace-period=0 --force 2>/dev/null || true
+      kubectl wait --for=delete pod -l app.kubernetes.io/instance=test-kafka,app.kubernetes.io/component=controller -n $NAMESPACE --timeout=120s 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Adds a `90-shutdown-kafka.yaml` step to all 11 kuttl test suites that gracefully scales down Kafka before kuttl deletes the namespace
- **ZK-mode tests** (7 suites): patches the CRD to set broker replicas to 0, with a force-delete fallback if pods don't terminate within 120s
- **KRaft-mode tests** (4 suites): scales brokers to 0 via CRD, deletes the KafkaCluster CR to stop operator reconciliation, then force-deletes controller pods (controllers can't be scaled via CRD due to a "no Kraft controllers found to build ConfigMap" error) 
- Sets `gracefulShutdownTimeout: 60s` in install templates to bound the worst-case shutdown wait (default is 30 minutes)
                    
## Problem

During namespace deletion, ZooKeeper/controllers and Kafka brokers are terminated simultaneously. In ZK-mode, Kafka's controlled-shutdown retries ZK connections indefinitely, keeping the process alive for the full `terminationGracePeriodSeconds` (up to 30 minutes) and blocking namespace deletion well past kuttl's 300s timeout.
                                                                                                                                                                            
## Test plan

- [x] Full nightly suite run (26/26 PASS) on Replicated k3s cluster (K8s 1.35.3)

Related: #956  

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
