### PR TITLE
chore: Bump vector to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ All notable changes to this project will be documented in this file.
   controllers).
   Previously, arbitrary file names were silently accepted and ignored ([#960]).
 - Bump `stackable-operator` to 0.111.1 and snafu to 0.9 ([#960], [#961]).
+- test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#971]).
 
 [#953]: https://github.com/stackabletech/kafka-operator/pull/953
 [#960]: https://github.com/stackabletech/kafka-operator/pull/960
 [#961]: https://github.com/stackabletech/kafka-operator/pull/961
+[#971]: https://github.com/stackabletech/kafka-operator/pull/971
 
 ## [26.3.0] - 2026-03-16
 

--- a/tests/templates/kuttl/logging/01-install-kafka-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-kafka-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install kafka-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.49.0
+      --version 0.52.0 `# app version 0.55.0`
       --repo https://helm.vector.dev
       --values kafka-vector-aggregator-values.yaml
 ---

--- a/tests/templates/kuttl/logging/test_log_aggregation.py
+++ b/tests/templates/kuttl/logging/test_log_aggregation.py
@@ -1,45 +1,40 @@
-#!/usr/bin/env python3
-import requests
+import json
+import subprocess
 
 
 def check_sent_events():
-    response = requests.post(
-        "http://kafka-vector-aggregator:8686/graphql",
-        json={
-            "query": """
-                {
-                    transforms(first:100) {
-                        nodes {
-                            componentId
-                            metrics {
-                                sentEventsTotal {
-                                    sentEventsTotal
-                                }
-                            }
-                        }
-                    }
-                }
-            """
-        },
+    response = subprocess.run(
+        [
+            "grpcurl",
+            "-plaintext",
+            "-d",
+            '{"limit": 100}',
+            "kafka-vector-aggregator:8686",
+            "vector.observability.v1.ObservabilityService/GetComponents",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,  # Raise a CalledProcessError if non-zero return
+        timeout=20,  # seconds
     )
+    result = json.loads(response.stdout)
+    components = result.get("components", [])
+    transforms = [
+        c for c in components if c.get("componentType") == "COMPONENT_TYPE_TRANSFORM"
+    ]
 
-    assert response.status_code == 200, (
-        "Cannot access the API of the vector aggregator."
-    )
+    assert len(transforms) > 0, "No transform components found"
 
-    result = response.json()
-
-    transforms = result["data"]["transforms"]["nodes"]
     for transform in transforms:
         sentEvents = transform["metrics"]["sentEventsTotal"]
         componentId = transform["componentId"]
 
         if componentId == "filteredInvalidEvents":
-            assert sentEvents is None or sentEvents["sentEventsTotal"] == 0, (
+            assert sentEvents is None or int(sentEvents) == 0, (
                 "Invalid log events were sent."
             )
         else:
-            assert sentEvents is not None and sentEvents["sentEventsTotal"] > 0, (
+            assert sentEvents is not None and int(sentEvents) > 0, (
                 f'No events were sent in "{componentId}".'
             )
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486

```
--- PASS: kuttl (95.98s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_kafka-3.9.1_zookeeper-latest-3.9.4_openshift-false (95.95s)
PASS
```