### PR TITLE
chore: Bump ZooKeeper version to 3.9.5 for SDP 26.7.0

### DIFF
--- a/docs/modules/kafka/examples/getting_started/zookeeper.yaml
+++ b/docs/modules/kafka/examples/getting_started/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleGroups:
       default:

--- a/docs/modules/kafka/examples/kraft_migration/01-setup.yaml
+++ b/docs/modules/kafka/examples/kraft_migration/01-setup.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: kraft-migration
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
     pullPolicy: IfNotPresent
   servers:
     roleGroups:

--- a/docs/modules/kafka/examples/mirror_maker/01-setup-source.yaml
+++ b/docs/modules/kafka/examples/mirror_maker/01-setup-source.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: mm-migration
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
     pullPolicy: IfNotPresent
   servers:
     roleGroups:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -23,9 +23,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.4
+      - 3.9.5
   - name: zookeeper-latest
     values:
-      - 3.9.4
+      - 3.9.5
   - name: opa-latest
     values:
       - 1.16.2


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.